### PR TITLE
Update context field 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Here is a template for new release sections
 ### Added
 -
 ### Changed
--
+- Update context field [PR#114]
 ### Removed
 -
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Here is a template for new release sections
 ### Added
 -
 ### Changed
-- Update context field [PR#114]
+- 
 ### Removed
 -
 
@@ -32,7 +32,7 @@ Here is a template for new release sections
 ### Added
 -
 ### Changed
--
+- Update context field [PR#114]
 ### Removed
 -
 

--- a/metadata/latest/example.json
+++ b/metadata/latest/example.json
@@ -380,7 +380,7 @@
         }
     ],
     "@id": "https://databus.dbpedia.org/kurzum/mastr/bnetza-mastr/01.04.00",
-    "@context": "https://github.com/OpenEnergyPlatform/oemetadata/blob/master/metadata/latest/context.json",
+    "@context": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/develop/metadata/latest/context.json",
     "review": {
         "path": "https://github.com/OpenEnergyPlatform/data-preprocessing/issues",
         "badge": "Platinum"

--- a/metadata/latest/template.json
+++ b/metadata/latest/template.json
@@ -170,7 +170,7 @@
         }
     ],
     "@id": null,
-    "@context": null,
+    "@context": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/develop/metadata/latest/context.json",
     "review": {
         "path": null,
         "badge": null

--- a/metadata/v151/example.json
+++ b/metadata/v151/example.json
@@ -373,7 +373,7 @@
         }
     ],
     "@id": "https://databus.dbpedia.org/kurzum/mastr/bnetza-mastr/01.04.00",
-    "@context": "https://github.com/OpenEnergyPlatform/oemetadata/blob/master/metadata/latest/context.json",
+    "@context": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/develop/metadata/latest/context.json",
     "review": {
         "path": "https://github.com/OpenEnergyPlatform/data-preprocessing/issues",
         "badge": "Platinum"

--- a/metadata/v151/template.json
+++ b/metadata/v151/template.json
@@ -170,7 +170,7 @@
         }
     ],
     "@id": null,
-    "@context": null,
+    "@context": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/develop/metadata/latest/context.json",
     "review": {
         "path": null,
         "badge": null

--- a/metadata/v152/example.json
+++ b/metadata/v152/example.json
@@ -380,7 +380,7 @@
         }
     ],
     "@id": "https://databus.dbpedia.org/kurzum/mastr/bnetza-mastr/01.04.00",
-    "@context": "https://github.com/OpenEnergyPlatform/oemetadata/blob/master/metadata/latest/context.json",
+    "@context": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/develop/metadata/latest/context.json",
     "review": {
         "path": "https://github.com/OpenEnergyPlatform/data-preprocessing/issues",
         "badge": "Platinum"

--- a/metadata/v152/template.json
+++ b/metadata/v152/template.json
@@ -170,7 +170,7 @@
         }
     ],
     "@id": null,
-    "@context": null,
+    "@context": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/develop/metadata/latest/context.json",
     "review": {
         "path": null,
         "badge": null


### PR DESCRIPTION
Closes #104 

* for all OEM versions that work with ontology

The field needs to link to raw-version of the file. I linked it to develop that one can change the `context.json` without making a relaease of the metadata and sparqling more metadata fields is possible when added in `context.json`