### PR TITLE
Add a key to make fields (columns) nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ Here is a template for new release sections
 
 - Add mandatory fields to the json schema (Iron Badge) [(#160)](https://github.com/OpenEnergyPlatform/oemetadata/pull/160)
 
+- Add key nullable to fields section (columns) [(#161)](https://github.com/OpenEnergyPlatform/oemetadata/pull/161)
+
 ### Changed
 
 - Remove comment field as it holds information on how to fill out the metadata and therefore should not be part of the actual oemetadata but the documentation. [#???](https://github.com/OpenEnergyPlatform/oemetadata/pull/)

--- a/metadata/v200_draft/build_source/schemas/resource.json
+++ b/metadata/v200_draft/build_source/schemas/resource.json
@@ -119,6 +119,16 @@
                                     "title": "Nullable",
                                     "readonly": true
                                 },
+                                "unit": {
+                                    "description": "The unit, preferably SI-unit, that values in this field are mapped to. If 'unit' doesn't apply to a field, use 'null'. If the unit is given in a seperate field, reference this field.",
+                                    "example": "MW",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "badge": "Silver",
+                                    "title": "Unit"
+                                },
                                 "isAbout": {
                                     "description": "Ontology URI to describe the column header",
                                     "type": "array",
@@ -198,16 +208,6 @@
                                     },
                                     "badge": "Platinum",
                                     "title": "valueReference"
-                                },
-                                "unit": {
-                                    "description": "The unit, preferably SI-unit, that values in this field are mapped to. If 'unit' doesn't apply to a field, use 'null'. If the unit is given in a seperate field, reference this field.",
-                                    "example": "MW",
-                                    "type": [
-                                        "string",
-                                        "null"
-                                    ],
-                                    "badge": "Silver",
-                                    "title": "Unit"
                                 }
                             },
                             "additionalProperties": false,

--- a/metadata/v200_draft/build_source/schemas/resource.json
+++ b/metadata/v200_draft/build_source/schemas/resource.json
@@ -108,7 +108,7 @@
                                     "title": "Type",
                                     "readonly": true
                                 },
-                                "isNullable": {
+                                "nullable": {
                                     "description": "A boolean key to specify that a column can be nullable. True is the default value.",
                                     "example": "True",
                                     "type": [
@@ -212,7 +212,7 @@
                             },
                             "additionalProperties": false,
                             "title": "Field",
-                            "required": ["name", "type", "isNullable"]
+                            "required": ["name", "type", "nullable"]
                         },
                         "title": "Field"
                     },

--- a/metadata/v200_draft/build_source/schemas/resource.json
+++ b/metadata/v200_draft/build_source/schemas/resource.json
@@ -108,6 +108,17 @@
                                     "title": "Type",
                                     "readonly": true
                                 },
+                                "isNullable": {
+                                    "description": "A boolean key to specify that a column can be nullable. True is the default value.",
+                                    "example": "True",
+                                    "type": [
+                                        "boolean",
+                                        "null"
+                                    ],
+                                    "badge": "Iron",
+                                    "title": "Nullable",
+                                    "readonly": true
+                                },
                                 "isAbout": {
                                     "description": "Ontology URI to describe the column header",
                                     "type": "array",
@@ -201,7 +212,7 @@
                             },
                             "additionalProperties": false,
                             "title": "Field",
-                            "required": ["name", "type"]
+                            "required": ["name", "type", "isNullable"]
                         },
                         "title": "Field"
                     },

--- a/metadata/v200_draft/metadata_key_description.md
+++ b/metadata/v200_draft/metadata_key_description.md
@@ -133,14 +133,15 @@ The JSON format offers different formats:
 | 16.6.1.1 | name | The name of the field. The name must consist of only lowercase alphanumeric characters or underscore. It must not start with a number or underscore. | year |
 | 16.6.1.2 | description | A text describing the field. | Reference year for which the data were collected. |
 | 16.6.1.3 | type | The data type of the field. In case of a geom column in a database, also indicate the shape and CRS. | geometry(Point, 4326) |
-| 16.6.1.4 | unit | The unit, preferably SI-unit, that values in this field are mapped to. If 'unit' doesn't apply to a field, use 'null'. If the unit is given in a seperate field, reference this field. | MW |
-| 16.6.1.5 | **isAbout** | An array of objects with describe the field in [OEO](https://openenergy-platform.org/ontology/oeo/) terms. | 
-| 16.6.1.5.1 | name | The class label of the OEO terms. | wind energy converting unit |
-| 16.6.1.5.2 | path | The URI of the class. | https://openenergy-platform.org/ontology/oeo/OEO_00000044 |
-| 16.6.1.6 | **valueReference** | An array of objects for an extended description of the values in the column in [OEO](https://openenergy-platform.org/ontology/oeo/) terms. | |
-| 16.6.1.6.1 | value | The name of the value in the column. | onshore |
-| 16.6.1.6.2 | name | The class label of the OEO terms. | onshore wind farm |
-| 16.6.1.6.3 | path | The URI of the class. | https://openenergy-platform.org/ontology/oeo/OEO_00000311 |
+| 16.6.1.4 | nullable | A boolean key to specify that a column can be nullable. True is the default value. | True |
+| 16.6.1.5 | unit | The unit, preferably SI-unit, that values in this field are mapped to. If 'unit' doesn't apply to a field, use 'null'. If the unit is given in a seperate field, reference this field. | MW |
+| 16.6.1.6 | **isAbout** | An array of objects with describe the field in [OEO](https://openenergy-platform.org/ontology/oeo/) terms. | 
+| 16.6.1.6.1 | name | The class label of the OEO terms. | wind energy converting unit |
+| 16.6.1.6.2 | path | The URI of the class. | https://openenergy-platform.org/ontology/oeo/OEO_00000044 |
+| 16.6.1.7 | **valueReference** | An array of objects for an extended description of the values in the column in [OEO](https://openenergy-platform.org/ontology/oeo/) terms. | |
+| 16.6.1.7.1 | value | The name of the value in the column. | onshore |
+| 16.6.1.7.2 | name | The class label of the OEO terms. | onshore wind farm |
+| 16.6.1.7.3 | path | The URI of the class. | https://openenergy-platform.org/ontology/oeo/OEO_00000311 |
 
 #### Resource Keys - Properties
 |#|Key |Description |Example |


### PR DESCRIPTION
## Summary of the discussion

To describe the table schema in the resource field, we need to add an option for nullable fields. As the schema field is also used for SQL table definitions, the nullable constraint is mandatory.

## Type of change (CHANGELOG.md)

### Added
- Add key nullable to fields section (columns) [(#161)](https://github.com/OpenEnergyPlatform/oemetadata/pull/161)

## Workflow checklist

### Automation
Closes #96
Closes #123

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oemetadata/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oemetadata/blob/develop/CHANGELOG.md)
- [x] 📙 Update the documentation

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/OpenEnergyPlatform/oemetadata/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
