### PR TITLE
Add key copyrightStatement to sources #127

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ Here is a template for new release sections
 
 - Add mandatory fields to the json schema (Iron Badge) [(#160)](https://github.com/OpenEnergyPlatform/oemetadata/pull/160)
 
+- Add key copyrightStatement to sources [(#162)](https://github.com/OpenEnergyPlatform/oemetadata/pull/162)
+
 ### Changed
 
 - Remove comment field as it holds information on how to fill out the metadata and therefore should not be part of the actual oemetadata but the documentation. [#???](https://github.com/OpenEnergyPlatform/oemetadata/pull/)

--- a/metadata/v200_draft/build_source/schemas/sources.json
+++ b/metadata/v200_draft/build_source/schemas/sources.json
@@ -97,6 +97,16 @@
                                     ],
                                     "badge": "Bronze",
                                     "title": "Attribution"
+                                },
+                                "copyrightStatement": {
+                                    "description": "A link or path that proves that the source or data has the appropriate license.",
+                                    "example": "https://www.marktstammdatenregister.de/MaStR/Startseite/Impressum",
+                                    "type": [
+                                        "string",
+                                        "null"
+                                    ],
+                                    "badge": "Bronze",
+                                    "title": "Copyright Statement"
                                 }
                             },
                             "badge": "Bronze",

--- a/metadata/v200_draft/metadata_key_description.md
+++ b/metadata/v200_draft/metadata_key_description.md
@@ -92,6 +92,7 @@ The JSON format offers different formats:
 | 12.4.3 | path | A link to the license text. | https://opendatacommons.org/licenses/odbl/1-0/index.html |
 | 12.4.4 | instruction | A short description of rights and restrictions. The use of [tl;drLegal](https://tldrlegal.com/) is recommended. | You are free to share and change, but you must attribute, and share derivations under the same license. See https://tldrlegal.com/license/odc-open-database-license-(odbl) for further information. |
 | 12.4.5 | attribution | The copyright owner of the **source**. If attribution licenses are used, that name must be acknowledged. | © Intergovernmental Panel on Climate Change 2014 |
+| 12.4.6 | copyrightStatement | A link or path that proves that the source or data has the appropriate license. | https://www.marktstammdatenregister.de/MaStR/Startseite/Impressum |
 
 ### License Keys
 |#|Key |Description |Example |


### PR DESCRIPTION
## Summary of the discussion

This old Blog post suggests a way of storing a link to the copyright information. This is very useful and has been missing.
Source: https://frictionlessdata.io/blog/2018/03/27/applying-licenses/#provide-additional-license-information

There is a suitable ontology from the Open Data Institut (ODI):
Original source: https://theodi.org/insights/guides/publishers-guide-to-the-open-data-rights-statement-vocabulary/
http://schema.theodi.org/odrs/

This is the corresponding property:
**odrs:copyrightStatement**

> A link to a document that includes a statement about the copyright status of the content of a dataset. The web page might include both a copyright notice for a dataset, and any relevant guidance for re-users.

-> Badge: Silver

## Type of change (CHANGELOG.md)

### Added
- Add key copyrightStatement to sources [(#162)](https://github.com/OpenEnergyPlatform/oemetadata/pull/162)

## Workflow checklist

### Automation
Closes #127

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oemetadata/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oemetadata/blob/develop/CHANGELOG.md)
- [x] 📙 Update the documentation

### Reviewer
- [x] 🐙 Follow the [Reviewer Guidelines](https://github.com/OpenEnergyPlatform/oemetadata/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
