### PR TITLE
Remove all additionalProperties constraint #132

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Here is a template for new release sections
 ### Removed
 
 - Remove email from contributors [(#157)](https://github.com/OpenEnergyPlatform/oemetadata/pull/157)
+- Remove all additionalProperties is false [(#163)](https://github.com/OpenEnergyPlatform/oemetadata/pull/163)
 
 ## [1.6.0] - Release - Introduce badges in json schema - 2023-05-30
 

--- a/metadata/v200_draft/build_source/schemas/context.json
+++ b/metadata/v200_draft/build_source/schemas/context.json
@@ -93,8 +93,7 @@
                 }
             },
             "badge": "Gold",
-            "title": "Context",
-            "additionalProperties": false
+            "title": "Context"
         }
     }
 }

--- a/metadata/v200_draft/build_source/schemas/general.json
+++ b/metadata/v200_draft/build_source/schemas/general.json
@@ -73,8 +73,7 @@
                     }
                 },
                 "badge": "Platinum",
-                "title": "Subject",
-                "additionalProperties": false
+                "title": "Subject"
             },
             "badge": "Platinum",
             "title": "Subject"
@@ -160,8 +159,7 @@
                 }
             },
             "badge": "Bronze",
-            "title": "Embargo Period",
-            "additionalProperties": false
+            "title": "Embargo Period"
         }
     },
     "required": ["name"]

--- a/metadata/v200_draft/build_source/schemas/json_ld.json
+++ b/metadata/v200_draft/build_source/schemas/json_ld.json
@@ -68,8 +68,7 @@
                 "version",
                 "used",
                 "license"
-            ],
-            "additionalProperties": false
+            ]
         }
     }
 }

--- a/metadata/v200_draft/build_source/schemas/licences.json
+++ b/metadata/v200_draft/build_source/schemas/licences.json
@@ -62,8 +62,7 @@
                     }
                 },
                 "badge": "Bronze",
-                "title": "Licenses",
-                "additionalProperties": false
+                "title": "Licenses"
             },
             "badge": "Bronze",
             "title": "Licenses"

--- a/metadata/v200_draft/build_source/schemas/meta.json
+++ b/metadata/v200_draft/build_source/schemas/meta.json
@@ -53,11 +53,9 @@
                         }
                     },
                     "badge": null,
-                    "title": "Metadata license",
-                    "additionalProperties": false
+                    "title": "Metadata license"
                 }
             },
-            "additionalProperties": false,
             "title": "Meta Metadata",
             "options": {
                 "hidden": true

--- a/metadata/v200_draft/build_source/schemas/provenance.json
+++ b/metadata/v200_draft/build_source/schemas/provenance.json
@@ -99,8 +99,7 @@
                 }
             },
             "badge": null,
-            "title": "Provenance",
-            "additionalProperties": false
+            "title": "Provenance"
         }
     }
 }

--- a/metadata/v200_draft/build_source/schemas/resource.json
+++ b/metadata/v200_draft/build_source/schemas/resource.json
@@ -137,8 +137,7 @@
                                             }
                                         },
                                         "badge": "Platinum",
-                                        "title": "isAbout",
-                                        "additionalProperties": false
+                                        "title": "isAbout"
                                     },
                                     "badge": "Platinum",
                                     "title": "isAbout"
@@ -182,8 +181,7 @@
                                             }
                                         },
                                         "badge": "Platinum",
-                                        "title": "valueReference",
-                                        "additionalProperties": false
+                                        "title": "valueReference"
                                     },
                                     "badge": "Platinum",
                                     "title": "valueReference"
@@ -199,7 +197,6 @@
                                     "title": "Unit"
                                 }
                             },
-                            "additionalProperties": false,
                             "title": "Field",
                             "required": ["name", "type"]
                         },
@@ -288,12 +285,10 @@
                                     },
                                     "badge": "Iron",
                                     "title": "Reference",
-                                    "additionalProperties": false,
                                     "required": ["resource", "fields"]
                                 }
                             },
                             "title": "Foreign Key",
-                            "additionalProperties": false,
                             "required": ["fields"]
                         },
                         "badge": "Iron",
@@ -301,7 +296,6 @@
                     }
                 },
                 "title": "Schema",
-                "additionalProperties": false,
                 "required": ["primaryKey"]
             },
             "dialect": {
@@ -329,7 +323,7 @@
                         "title": "Decimal separator"
                     }
                 },
-                "additionalProperties": false,
+                "badge": "Silver",
                 "title": "Dialect",
                 "options": {
                     "hidden": true

--- a/metadata/v200_draft/build_source/schemas/review.json
+++ b/metadata/v200_draft/build_source/schemas/review.json
@@ -28,7 +28,6 @@
                     "title": "Badge"
                 }
             },
-            "additionalProperties": false,
             "title": "Review",
             "options": {
                 "hidden": true

--- a/metadata/v200_draft/build_source/schemas/sources.json
+++ b/metadata/v200_draft/build_source/schemas/sources.json
@@ -107,8 +107,7 @@
                     }
                 },
                 "badge": "Bronze",
-                "title": "Sources",
-                "additionalProperties": false
+                "title": "Sources"
             },
             "badge": "Bronze",
             "title": "Sources"

--- a/metadata/v200_draft/build_source/schemas/spatial.json
+++ b/metadata/v200_draft/build_source/schemas/spatial.json
@@ -39,8 +39,7 @@
                 }
             },
             "badge": "Silver",
-            "title": "Spatial",
-            "additionalProperties": false
+            "title": "Spatial"
         }
     }
 }

--- a/metadata/v200_draft/build_source/schemas/temporal.json
+++ b/metadata/v200_draft/build_source/schemas/temporal.json
@@ -78,16 +78,14 @@
                             }
                         },
                         "badge": "Silver",
-                        "title": "Timeseries",
-                        "additionalProperties": false
+                        "title": "Timeseries"
                     },
                     "badge": "Silver",
                     "title": "Timeseries"
                 }
             },
             "badge": "Silver",
-            "title": "Temporal",
-            "additionalProperties": false
+            "title": "Temporal"
         }
     }
 }


### PR DESCRIPTION
## Summary of the discussion

As suggested in #132 the flag _additionalProperties: false_ gives warnings when validating datapackages.

## Type of change (CHANGELOG.md)

### Removed
- Remove all additionalProperties is false [(#163)](https://github.com/OpenEnergyPlatform/oemetadata/pull/163)

## Workflow checklist

### Automation
Closes #132

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oemetadata/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oemetadata/blob/develop/CHANGELOG.md)
- [x] 📙 Update the documentation

### Reviewer
- [x] 🐙 Follow the [Reviewer Guidelines](https://github.com/OpenEnergyPlatform/oemetadata/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [x] 🐙 Provided feedback and show sufficient appreciation for the work done
