### PR TITLE
Add explicit json types #146

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ Here is a template for new release sections
 
 - Add key nullable to fields section (columns) [(#161)](https://github.com/OpenEnergyPlatform/oemetadata/pull/161)
 
+- Add explicit json types [(#166)](https://github.com/OpenEnergyPlatform/oemetadata/pull/166)
+
 ### Changed
 
 - Remove comment field as it holds information on how to fill out the metadata and therefore should not be part of the actual oemetadata but the documentation. [#???](https://github.com/OpenEnergyPlatform/oemetadata/pull/)

--- a/metadata/v200_draft/build_source/schemas/general.json
+++ b/metadata/v200_draft/build_source/schemas/general.json
@@ -135,7 +135,8 @@
                         "null"
                     ],
                     "badge": "Bronze",
-                    "title": "Embargo Period Start"
+                    "title": "Embargo Period Start",
+                    "format": "date"
                 },
                 "end": {
                     "description": "The end date of the embargo period. This is the intended publication date.",
@@ -145,7 +146,8 @@
                         "null"
                     ],
                     "badge": "Bronze",
-                    "title": "Embargo Period End (Publication Date)"
+                    "title": "Embargo Period End (Publication Date)",
+                    "format": "date"
                 },
                 "isActive": {
                     "description": "A boolean key that indicates if the embargo period is currently active. Must be changed to False on the embargo period end date.",

--- a/metadata/v200_draft/build_source/schemas/general_collection.json
+++ b/metadata/v200_draft/build_source/schemas/general_collection.json
@@ -32,6 +32,7 @@
             ],
             "badge": "Silver",
             "title": "Collection identifier",
+            "format": "uri",
             "readonly": true
         }
     },

--- a/metadata/v200_draft/build_source/schemas/licences.json
+++ b/metadata/v200_draft/build_source/schemas/licences.json
@@ -38,7 +38,8 @@
                             "null"
                         ],
                         "badge": "Bronze",
-                        "title": "Path"
+                        "title": "Path",
+                        "format": "uri"
                     },
                     "instruction": {
                         "description": "A short description of rights and restrictions. The use of tl;drLegal is recommended.",
@@ -51,7 +52,7 @@
                         "title": "Instruction"
                     },
                     "attribution": {
-                        "description": "The copyrightholder of the data set. If attribution licenses are used, that name must be acknowledged.",
+                        "description": "The copyright holder of the data set. If attribution licenses are used, that name must be acknowledged.",
                         "example": "© Reiner Lemoine Institut",
                         "type": [
                             "string",

--- a/metadata/v200_draft/build_source/schemas/meta.json
+++ b/metadata/v200_draft/build_source/schemas/meta.json
@@ -15,7 +15,7 @@
                         "null"
                     ],
                     "badge": null,
-                    "title": "Metadata version"
+                    "title": "Metadata Version"
                 },
                 "metadataLicense": {
                     "description": "Object describing the license of the provided metadata.",
@@ -49,11 +49,12 @@
                                 "null"
                             ],
                             "badge": null,
-                            "title": "Path"
+                            "title": "Path",
+                            "format": "uri"
                         }
                     },
                     "badge": null,
-                    "title": "Metadata license"
+                    "title": "Metadata License"
                 }
             },
             "title": "Meta Metadata",

--- a/metadata/v200_draft/build_source/schemas/provenance.json
+++ b/metadata/v200_draft/build_source/schemas/provenance.json
@@ -61,17 +61,18 @@
                                 "title": "Roles"
                             },
                             "date": {
-                                "description": "Date of the contribution. If the contribution took more than a day, use the date of the final contribiution. Date Format is ISO 8601.",
+                                "description": "The date of the final contribution. Date Format is ISO 8601.",
                                 "example": "2016-06-16",
                                 "type": [
                                     "string",
                                     "null"
                                 ],
                                 "badge": null,
-                                "title": "Date"
+                                "title": "Date",
+                                "format": "date"
                             },
                             "object": {
-                                "description": "Target of contribution. Which part of the package was supplied/changed.",
+                                "description": "Target of contribution. Which part of the package was supplied or changed.",
                                 "example": "data and metadata",
                                 "type": [
                                     "string",
@@ -82,7 +83,7 @@
                             },
                             "comment": {
                                 "description": "Free text comment on what has been done.",
-                                "example": "Fix typo in the title.",
+                                "example": "Add general context.",
                                 "type": [
                                     "string",
                                     "null"


### PR DESCRIPTION
## Summary of the discussion

The [JSON schema spec](https://json-schema.org/understanding-json-schema/reference/string#built-in-formats) allows some build in additional types.
Used options are:

- "date": 2018-11-13
- "date-time": 2018-11-13T20:20:39+00:00
- "uri": A universal resource identifier (URI), according to [RFC3986](http://tools.ietf.org/html/rfc3986).

## Type of change (CHANGELOG.md)

### Added
- Add explicit json types [(#166)](https://github.com/OpenEnergyPlatform/oemetadata/pull/166)

## Workflow checklist

### Automation
Closes #146

### PR-Assignee
- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oemetadata/blob/develop/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oemetadata/blob/develop/CHANGELOG.md)
- [x] 📙 Update the documentation

### Reviewer
- [ ] 🐙 Follow the [Reviewer Guidelines](https://github.com/OpenEnergyPlatform/oemetadata/blob/develop/CONTRIBUTING.md#40-let-someone-else-review-your-pr)
- [ ] 🐙 Provided feedback and show sufficient appreciation for the work done
