### PR TITLE
Add dataset creator to contributors

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -111,6 +111,22 @@ SPDX-FileCopyrightText = ["2024 Ludwig Hülk <@Ludee> © Reiner Lemoine Institut
 SPDX-License-Identifier = "MIT"
 
 [[annotations]]
+path = "oemetadata/v2/v21/*.json"
+precedence = "override"
+SPDX-FileCopyrightText = ["2026 Ludwig Hülk <@Ludee> © Reiner Lemoine Institut",
+    "2026 Jonas Huber <@jh-RLI> © Reiner Lemoine Institut",
+    "oemetadata <https://github.com/OpenEnergyPlatform/oemetadata/>"]
+SPDX-License-Identifier = "MIT"
+
+[[annotations]]
+path = "oemetadata/v2/v21/build_source/schemas/*.json"
+precedence = "override"
+SPDX-FileCopyrightText = ["2026 Ludwig Hülk <@Ludee> © Reiner Lemoine Institut",
+    "2026 Jonas Huber <@jh-RLI> © Reiner Lemoine Institut",
+    "oemetadata <https://github.com/OpenEnergyPlatform/oemetadata/>"]
+SPDX-License-Identifier = "MIT"
+
+[[annotations]]
 path = "oemetadata/latest/*.json"
 precedence = "override"
 SPDX-FileCopyrightText = ["2024 Ludwig Hülk <@Ludee> © Reiner Lemoine Institut",

--- a/oemetadata/v2/v21/README.md
+++ b/oemetadata/v2/v21/README.md
@@ -1,0 +1,25 @@
+<!--
+SPDX-FileCopyrightText: 2024 Ludwig Hülk <Ludee> © Reiner Lemoine Institut
+SPDX-FileCopyrightText: 2024 Jonas Huber <jh-RLI> © Reiner Lemoine Institut
+
+SPDX-License-Identifier: MIT
+-->
+
+<a href="https://github.com/OpenEnergyPlatform/oemetadata/"><img align="right" width="100" height="100" src="https://raw.githubusercontent.com/OpenEnergyPlatform/organisation/production/logo/OpenEnergyFamily_Logo_OEMetadata.png" alt="OpenEnergyMetadata"></a>
+<a href="https://openenergyplatform.org/"><img align="right" width="100" height="100" src="https://avatars2.githubusercontent.com/u/37101913?s=400&u=9b593cfdb6048a05ea6e72d333169a65e7c922be&v=4" alt="OpenEnergyPlatform"></a>
+
+
+# OEMetadata - Version 2.0
+
+This version of the OEMetadata represents the latest released version.
+This release is fully integrated into the OEP.
+
+The OEMetadata contains the following files:
+
+* [template.json](https://github.com/OpenEnergyPlatform/oemetadata/blob/production/oemetadata/latest/template.json) contains an empty metadata string with all fields.
+* [example.json](https://github.com/OpenEnergyPlatform/oemetadata/blob/production/oemetadata/latest/example.json) contains a basic metadata example.
+* [metadata_key_description.md](https://github.com/OpenEnergyPlatform/oemetadata/blob/production/oemetadata/latest/metadata_key_description.md) contains a full description of each metadata key and an example.
+* [context.json](https://github.com/OpenEnergyPlatform/oemetadata/blob/production/oemetadata/latest/context.json) contains the references of metadata keys in ontology terms.
+* [schema.json](https://github.com/OpenEnergyPlatform/oemetadata/blob/production/oemetadata/latest/schema.json) contains the json schema for the metadata.
+
+For further information see the [Changelog](https://github.com/OpenEnergyPlatform/oemetadata/blob/production/CHANGELOG.md).

--- a/oemetadata/v2/v21/build_source/README.md
+++ b/oemetadata/v2/v21/build_source/README.md
@@ -1,0 +1,52 @@
+<!--
+SPDX-FileCopyrightText: 2024 Ludwig Hülk <Ludee> © Reiner Lemoine Institut
+SPDX-FileCopyrightText: 2024 Jonas Huber <jh-RLI> © Reiner Lemoine Institut
+SPDX-FileCopyrightText: oemetadata <https://github.com/OpenEnergyPlatform/oemetadata/>
+SPDX-License-Identifier: MIT
+-->
+
+# OEMetadata Build Source
+
+The OEMetadata uses the [JSON Schema](https://json-schema.org/) specification
+to define the structure of the metadata. <br>
+It offers the possibility to make the `schema.json` more modular. <br>
+For better maintenance the file is split into separate files. <br>
+The `schema_structure.json` contains the overall pattern of the structure.
+
+## Structure
+
+The directory `build_source` contains two parts:
+
+### Schemas `build_source/schemas/`
+
+The schemas are the core of the OEMetadata specification. <br>
+They are separated by category and follow the logic of OEMetadata structure.
+
+
+### Scripts `build_source/scripts/`
+
+- `create_schema.py` Creates the complete `schema.json` from `schemas`
+- `create_template.py` Creates the `template.json` from `schema.json`
+- `create_example.py` Creates the `example.json` from `schema.json`
+
+## Usage
+
+Create a python3 environment
+
+    cd ../oemetadata/
+    python3 -m venv env
+
+Install the requirements
+
+    source env/bin/activate
+    pip install -r requirements.txt
+
+Create the OEMetadata json schema from schemas
+
+    cd metadata/v2/v20/build_source/scripts/
+    python metadata/v2/v20/build_source/scripts/create_schema.py
+
+Create the OEMetadata template and example from json schema
+
+    python metadata/v2/v20/build_source/scripts/create_example_from_schema.py
+    python metadata/v2/v20/build_source/scripts/create_template_from_schema.py

--- a/oemetadata/v2/v21/build_source/schema_structure.json
+++ b/oemetadata/v2/v21/build_source/schema_structure.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/v2/v20/schema.json",
+  "description": "Open Energy Metadata (OEMetadata) - metadata schema",
+  "type": "object",
+  "required": [
+    "resources"
+  ],
+  "properties": {
+    "collection": {
+      "$ref": "dataset.json#"
+    },
+    "resources": {
+      "description": "A collection of related resources.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "general": {
+            "$ref": "general.json#"
+          },
+          "context": {
+            "$ref": "context.json#"
+          },
+          "spatial": {
+            "$ref": "spatial.json#"
+          },
+          "temporal": {
+            "$ref": "temporal.json#"
+          },
+          "sources": {
+            "$ref": "sources.json#"
+          },
+          "licenses": {
+            "$ref": "licenses.json#"
+          },
+          "provenance": {
+            "$ref": "provenance.json#"
+          },
+          "resource": {
+            "$ref": "fields.json#"
+          },
+          "review": {
+            "$ref": "review.json#"
+          }
+        }
+      },
+      "title": "Resources"
+    },
+    "meta": {
+      "$ref": "meta.json#"
+    }
+  },
+  "additionalProperties": true
+}

--- a/oemetadata/v2/v21/build_source/schema_structure.json.license
+++ b/oemetadata/v2/v21/build_source/schema_structure.json.license
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: 2024 Ludwig Hülk <@Ludee> © Reiner Lemoine Institut
+# SPDX-FileCopyrightText: 2024 Jonas Huber <jh-RLI> © Reiner Lemoine Institut
+# SPDX-FileCopyrightText: 2024 Christian Hofmann <christian-rli> © Reiner Lemoine Institut
+# SPDX-FileCopyrightText: oemetadata <https://github.com/OpenEnergyPlatform/oemetadata/>
+# SPDX-License-Identifier: MIT

--- a/oemetadata/v2/v21/build_source/schemas/context.json
+++ b/oemetadata/v2/v21/build_source/schemas/context.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/v2/v20/build_source/schemas/context.json",
+  "type": "object",
+  "properties": {
+    "context": {
+      "description": "An Object that describes the general setting, environment or project leading to the creation or maintenance of this dataset. In science this can be the research project.",
+      "type": "object",
+      "properties": {
+        "title": {
+          "description": "A title of the associated project.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "examples": [
+            "NFDI4Energy"
+          ],
+          "badge": "Gold",
+          "title": "Context Title"
+        },
+        "homepage": {
+          "description": "A URL of the project.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "examples": [
+            "https://nfdi4energy.uol.de/"
+          ],
+          "badge": "Gold",
+          "title": "Homepage",
+          "format": "uri"
+        },
+        "documentation": {
+          "description": "A URL of the project documentation.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "examples": [
+            "https://nfdi4energy.uol.de/sites/about_us/"
+          ],
+          "badge": "Gold",
+          "title": "Documentation"
+        },
+        "sourceCode": {
+          "description": "A URL of the source code of the project.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "examples": [
+            "https://github.com/NFDI4Energy"
+          ],
+          "badge": "Gold",
+          "title": "Source Code"
+        },
+        "publisher": {
+          "description": "The publishing agency of the data. This can be the OEP.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "examples": [
+            "Open Energy Platform (OEP)"
+          ],
+          "badge": "Bronze",
+          "title": "Publisher"
+        },
+        "publisherLogo": {
+          "description": "A URL to the logo of the publishing agency of data.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "examples": [
+            "https://github.com/OpenEnergyPlatform/organisation/blob/production/logo/OpenEnergyFamily_Logo_OpenEnergyPlatform.svg"
+          ],
+          "badge": "Gold",
+          "title": "Publisher Logo",
+          "format": "uri"
+        },
+        "contact": {
+          "description": "A reference to the creator or maintainer of the data set. This can be an email address or a GitHub handle.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "examples": [
+            "contact@example.com"
+          ],
+          "badge": "Gold",
+          "title": "E-Mail Contact",
+          "format": "email"
+        },
+        "fundingAgency": {
+          "description": "A name of the entity providing the funding. This can be a government agency or a company.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "examples": [
+            " Deutsche Forschungsgemeinschaft (DFG)"
+          ],
+          "badge": "Gold",
+          "title": "Funding Agency"
+        },
+        "fundingAgencyLogo": {
+          "description": "A URL to the logo or image of the funding agency.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "examples": [
+            "https://upload.wikimedia.org/wikipedia/commons/8/86/DFG-logo-blau.svg"
+          ],
+          "badge": "Gold",
+          "title": "Funding Agency Logo",
+          "format": "uri"
+        },
+        "grantNo": {
+          "description": "An identifying grant number. In case of a publicly funded project, this number is assigned by the funding agency.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "examples": [
+            "501865131"
+          ],
+          "badge": "Gold",
+          "title": "Grant Number"
+        }
+      },
+      "badge": "Gold",
+      "title": "Context"
+    }
+  }
+}

--- a/oemetadata/v2/v21/build_source/schemas/dataset.json
+++ b/oemetadata/v2/v21/build_source/schemas/dataset.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/v2/v20/build_source/schemas/collection.json",
+  "type": "object",
+  "properties": {
+    "@context": {
+      "description": "Explanation of metadata keys in ontology terms.",
+      "examples": [
+        "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/latest/context.json"
+      ],
+      "type": [
+        "string",
+        "null"
+      ],
+      "badge": "Platinum",
+      "title": "@context",
+      "readOnly": true
+    },
+    "name": {
+      "description": "A filename or database conform dataset name.",
+      "type": [
+        "string",
+        "null"
+      ],
+      "examples": [
+        "oep_oemetadata"
+      ],
+      "badge": "Iron",
+      "title": "Dataset Name"
+    },
+    "title": {
+      "description": "A human readable dataset name.",
+      "type": [
+        "string",
+        "null"
+      ],
+      "examples": [
+        "OEP OEMetadata"
+      ],
+      "badge": "Bronze",
+      "title": "Dataset Title"
+    },
+    "description": {
+      "description": "A free text description of the dataset.",
+      "type": [
+        "string",
+        "null"
+      ],
+      "examples": [
+        "A dataset for the OEMetadata examples."
+      ],
+      "badge": "Bronze",
+      "title": "Dataset Description"
+    },
+    "@id": {
+      "description": "A unique identifier (UUID/DOI) for the collection.",
+      "type": [
+        "string",
+        "null"
+      ],
+      "examples": [
+        "https://databus.openenergyplatform.org/oeplatform/supply/wri_global_power_plant_database/"
+      ],
+      "badge": "Platinum",
+      "title": "Dataset Identifier",
+      "format": "uri",
+      "readOnly": true
+    }
+  },
+  "required": [
+    "name"
+  ]
+}

--- a/oemetadata/v2/v21/build_source/schemas/fields.json
+++ b/oemetadata/v2/v21/build_source/schemas/fields.json
@@ -1,0 +1,360 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/v2/v20/build_source/schemas/fields.json",
+  "type": "object",
+  "properties": {
+    "type": {
+      "description": "The 'table' type indicates that the resource is tabular as per 'Frictionless Tabular Data' definition.",
+      "type": [
+        "string",
+        "null"
+      ],
+      "examples": [
+        "table"
+      ],
+      "badge": "Gold",
+      "title": "Type",
+      "options": {
+        "hidden": true
+      }
+    },
+    "format": {
+      "description": "A file extension format. Possible options are 'csv', 'xlsx', 'json', 'PostgreSQL', 'SQLite' and other standard file extensions.",
+      "type": [
+        "string",
+        "null"
+      ],
+      "examples": [
+        "CSV"
+      ],
+      "badge": "Gold",
+      "title": "Format",
+      "options": {
+        "hidden": true
+      }
+    },
+    "encoding": {
+      "description": "Specifies the character encoding of the resource's data file. The default is 'UTF-8'. The values should be one of the 'Preferred MIME Names'.",
+      "type": [
+        "string",
+        "null"
+      ],
+      "examples": [
+        "UTF-8"
+      ],
+      "badge": "Gold",
+      "title": "Encoding",
+      "options": {
+        "hidden": true
+      }
+    },
+    "schema": {
+      "description": "An object that describes the structure of a table. It contains all fields (columns of the table), the primary key and optional foreign keys.",
+      "type": "object",
+      "properties": {
+        "fields": {
+          "description": "An array of objects that describes a field (column) and its detailed information.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "description": "The name of the field. The name may only consist of lowercase alphanumeric characters or underscores. It must not begin with a number or an underscore.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "examples": [
+                  "year"
+                ],
+                "badge": "Iron",
+                "title": "Column Name",
+                "readOnly": true
+              },
+              "description": {
+                "description": "A text describing the field.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "examples": [
+                  "Reference year for which the data was collected."
+                ],
+                "badge": "Silver",
+                "title": "Description"
+              },
+              "type": {
+                "description": "The data type of the field. In case of a geom column in a database, also indicate the shape and CRS.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "examples": [
+                  "geometry(Point, 4326)"
+                ],
+                "badge": "Iron",
+                "title": "Type",
+                "readOnly": true
+              },
+              "nullable": {
+                "description": "A boolean key to specify that a column can be nullable. True is the default value.",
+                "type": [
+                  "boolean",
+                  "null"
+                ],
+                "examples": [
+                  true
+                ],
+                "badge": "Iron",
+                "title": "Nullable",
+                "readOnly": true
+              },
+              "unit": {
+                "description": "The unit of a field. If it does not apply, use 'null'. If the unit is given in a separate field, reference this field (e.g. 'unit'). Use a space between numbers and units (100 m).",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "examples": [
+                  "MW"
+                ],
+                "badge": "Silver",
+                "title": "Unit"
+              },
+              "isAbout": {
+                "description": "An array of objects that describes the field in ontology terms.",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "description": "The class label of the ontology term.",
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "examples": [
+                        "wind energy converting unit"
+                      ],
+                      "badge": "Platinum",
+                      "title": "Is About Name"
+                    },
+                    "@id": {
+                      "description": "The path of the ontology term (IRI).",
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "examples": [
+                        "https://openenergyplatform.org/ontology/oeo/OEO_00000044"
+                      ],
+                      "badge": "Platinum",
+                      "title": "Is About Identifier",
+                      "format": "uri"
+                    }
+                  },
+                  "badge": "Platinum",
+                  "title": "isAbout"
+                },
+                "badge": "Platinum",
+                "title": "isAbout"
+              },
+              "valueReference": {
+                "description": "An array of objects for an extended description of the values in the column in ontology terms.",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "description": "The name of the value in the column.",
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "examples": [
+                        "onshore"
+                      ],
+                      "badge": "Platinum",
+                      "title": "Value Reference"
+                    },
+                    "name": {
+                      "description": "The class label of the ontology term in the column.",
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "examples": [
+                        "onshore wind farm"
+                      ],
+                      "badge": "Platinum",
+                      "title": "Value Reference Name"
+                    },
+                    "@id": {
+                      "description": "The path of the ontology term (IRI) in the column.",
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "examples": [
+                        "https://openenergyplatform.org/ontology/oeo/OEO_00000311"
+                      ],
+                      "badge": "Platinum",
+                      "title": "Value Reference Identifier",
+                      "format": "uri"
+                    }
+                  },
+                  "badge": "Platinum",
+                  "title": "valueReference"
+                },
+                "badge": "Platinum",
+                "title": "valueReference"
+              }
+            },
+            "title": "Field",
+            "required": [
+              "name",
+              "type",
+              "nullable"
+            ]
+          },
+          "title": "Field"
+        },
+        "primaryKey": {
+          "description": "An array of fields that uniquely identifies each row in the table.",
+          "type": "array",
+          "items": {
+            "description": "The default value is the “id” column.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "examples": [
+              "id"
+            ],
+            "badge": "Iron",
+            "title": "Primary key"
+          },
+          "badge": "Iron",
+          "title": "Primary key"
+        },
+        "foreignKeys": {
+          "description": "List of foreign keys.",
+          "type": "array",
+          "items": {
+            "description": "An array of objects with foreign keys that describe a field that relates to a field in another table.",
+            "type": "object",
+            "properties": {
+              "fields": {
+                "description": "An array of fields in the table that is constrained by the foreign key.",
+                "type": "array",
+                "items": {
+                  "description": "The column in the table that is constrained by the foreign key.",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "examples": [
+                    "id",
+                    "version"
+                  ],
+                  "badge": "Iron",
+                  "title": "Foreign Key Field"
+                },
+                "badge": "Iron",
+                "title": "Fields"
+              },
+              "reference": {
+                "description": "The reference to the foreign table.",
+                "type": "object",
+                "properties": {
+                  "resource": {
+                    "description": "The referenced foreign table.",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "examples": [
+                      "model_draft.oep_oemetadata_table_example_version"
+                    ],
+                    "badge": "Iron",
+                    "title": "Foreign Resource"
+                  },
+                  "fields": {
+                    "description": "The foreign resource column.",
+                    "type": "array",
+                    "items": {
+                      "description": "The foreign resource column.",
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "examples": [
+                        "id",
+                        "version"
+                      ],
+                      "badge": "Iron",
+                      "title": "Field"
+                    },
+                    "badge": "Iron",
+                    "title": "Field"
+                  }
+                },
+                "badge": "Iron",
+                "title": "Reference",
+                "required": [
+                  "resource",
+                  "fields"
+                ]
+              }
+            },
+            "title": "Foreign Key",
+            "required": [
+              "fields"
+            ]
+          },
+          "badge": "Iron",
+          "title": "Foreign Keys"
+        }
+      },
+      "title": "Schema",
+      "required": [
+        "primaryKey"
+      ]
+    },
+    "dialect": {
+      "description": "The Dialect defines a simple format for describing the various dialects of CSV files in a language-independent manner. In a database, the values in the fields are 'null'.",
+      "type": "object",
+      "properties": {
+        "delimiter": {
+          "description": "The delimiter specifies the character sequence which should separate fields (columns). Common characters are ',' (comma), ';' (semicolon), '.' (point) and '\\t' (tab).",
+          "type": [
+            "string",
+            "null"
+          ],
+          "examples": [
+            ";"
+          ],
+          "badge": "Silver",
+          "title": "Delimiter"
+        },
+        "decimalSeparator": {
+          "description": "The symbol used to separate the integer part from the fractional part of a number written in decimal form. Depending on language and region this symbol can be '.' or ','.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "examples": [
+            "."
+          ],
+          "badge": "Silver",
+          "title": "Decimal separator"
+        }
+      },
+      "badge": "Silver",
+      "title": "Dialect",
+      "options": {
+        "hidden": true
+      }
+    }
+  }
+}

--- a/oemetadata/v2/v21/build_source/schemas/general.json
+++ b/oemetadata/v2/v21/build_source/schemas/general.json
@@ -1,0 +1,226 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/v2/v20/build_source/schemas/general.json",
+  "type": "object",
+  "properties": {
+    "@id": {
+      "description": "A Uniform Resource Identifier (URI) that links the resource via the OpenEnergyDatabus (DBpedia Databus).",
+      "type": [
+        "string",
+        "null"
+      ],
+      "examples": [
+        "https://databus.openenergyplatform.org/oeplatform/supply/wri_global_power_plant_database/2022-11-07/wri_global_power_plant_database_variant=data.csv"
+      ],
+      "badge": "Platinum",
+      "title": "@Id",
+      "readOnly": true
+    },
+    "name": {
+      "description": "A filename or database conform table name.",
+      "type": [
+        "string",
+        "null"
+      ],
+      "examples": [
+        "oemetadata_table_template"
+      ],
+      "badge": "Iron",
+      "title": "Name"
+    },
+    "topics": {
+      "description": "An array of predefined topics that correspond to the database schemas of the OEP.",
+      "type": "array",
+      "items": {
+        "description": "The topics are used to group the data in the database.",
+        "type": [
+          "string",
+          "null"
+        ],
+        "examples": [
+          "model_draft"
+        ],
+        "badge": "Bronze",
+        "title": "Topic"
+      },
+      "badge": "Bronze",
+      "title": "Topics"
+    },
+    "title": {
+      "description": "A human readable resource or table name.",
+      "type": [
+        "string",
+        "null"
+      ],
+      "examples": [
+        "OEMetadata Table Template"
+      ],
+      "badge": "Silver",
+      "title": "Title"
+    },
+    "path": {
+      "description": "A unique identifier (URI/UUID/DOI) for the table or file.",
+      "type": [
+        "string",
+        "null"
+      ],
+      "examples": [
+        "http://openenergyplatform.org/dataedit/view/model_draft/oemetadata_table_template"
+      ],
+      "badge": "Bronze",
+      "title": "Path",
+      "readOnly": true
+    },
+    "description": {
+      "description": "A description of the table. It should be usable as summary information for the table that is described by the metadata.",
+      "type": [
+        "string",
+        "null"
+      ],
+      "examples": [
+        "Example table used to illustrate the OEMetadata structure and features."
+      ],
+      "badge": "Silver",
+      "title": "Description"
+    },
+    "languages": {
+      "description": "An array of languages used within the described data structures (e.g. titles, descriptions) or metadata.",
+      "type": "array",
+      "items": {
+        "description": "The language keys must follow the Standard IETF (BCP47) and can be repeated if more languages are used.",
+        "type": [
+          "string",
+          "null"
+        ],
+        "examples": [
+          "en-GB",
+          "de-DE"
+        ],
+        "badge": "Gold",
+        "title": "Language"
+      },
+      "badge": "Gold",
+      "title": "Languages"
+    },
+    "subject": {
+      "description": "An array of objects that references to the subjects of the resource in ontology terms.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "A class label of the ontology term.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "examples": [
+              "energy"
+            ],
+            "badge": "Platinum",
+            "title": "Subject Name"
+          },
+          "@id": {
+            "description": "A unique identifier (URI/IRI) of the ontology class.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "examples": [
+              "https://openenergyplatform.org/ontology/oeo/OEO_00000150"
+            ],
+            "badge": "Platinum",
+            "title": "Subject Identifier",
+            "format": "uri"
+          }
+        },
+        "badge": "Platinum",
+        "title": "Subject"
+      },
+      "badge": "Platinum",
+      "title": "Subject"
+    },
+    "keywords": {
+      "description": "An array of freely selectable keywords that help with searching and structuring.",
+      "type": "array",
+      "items": {
+        "description": "The keyword are used and managed in the OEP as table tags.",
+        "type": [
+          "string",
+          "null"
+        ],
+        "examples": [
+          "example",
+          "ODbL-1.0",
+          "NFDI4Energy"
+        ],
+        "badge": "Silver",
+        "title": "Keyword"
+      },
+      "badge": "Silver",
+      "title": "Keywords"
+    },
+    "publicationDate": {
+      "description": "A date of publication of the data or metadata. The date format is ISO 8601 (YYYY-MM-DD).",
+      "type": [
+        "string",
+        "null"
+      ],
+      "examples": [
+        "2024-10-15"
+      ],
+      "badge": "Bronze",
+      "title": "Publication Date",
+      "format": "date"
+    },
+    "embargoPeriod": {
+      "description": "An object that describes the embargo period during which public access to the data is not allowed.",
+      "type": "object",
+      "properties": {
+        "start": {
+          "description": "The start date of the embargo period. The date of the data (metadata) upload.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "examples": [
+            "2024-10-11"
+          ],
+          "badge": "Bronze",
+          "title": "Embargo Period Start",
+          "format": "date"
+        },
+        "end": {
+          "description": "The end date of the embargo period. This is the intended publication date.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "examples": [
+            "2025-01-01"
+          ],
+          "badge": "Bronze",
+          "title": "Embargo Period End (Publication Date)",
+          "format": "date"
+        },
+        "isActive": {
+          "description": "A boolean key that indicates if the embargo period is currently active. Must be changed to False on the embargo period end date.",
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "examples": [
+            true
+          ],
+          "badge": "Bronze",
+          "title": "Embargo Period is Active "
+        }
+      },
+      "badge": "Bronze",
+      "title": "Embargo Period"
+    }
+  },
+  "required": [
+    "name"
+  ]
+}

--- a/oemetadata/v2/v21/build_source/schemas/licenses.json
+++ b/oemetadata/v2/v21/build_source/schemas/licenses.json
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/v2/v20/build_source/schemas/licenses.json",
+  "type": "object",
+  "properties": {
+    "licenses": {
+      "description": "An array of objects of licenses under which the described data is provided.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "The SPDX identifier.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "examples": [
+              "ODbL-1.0"
+            ],
+            "badge": "Bronze",
+            "title": "Name"
+          },
+          "title": {
+            "description": "The official (human readable) title of the license.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "examples": [
+              "Open Data Commons Open Database License 1.0"
+            ],
+            "badge": "Bronze",
+            "title": "Title"
+          },
+          "path": {
+            "description": "A link or path to the license text.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "examples": [
+              "https://opendatacommons.org/licenses/odbl/1-0/index.html"
+            ],
+            "badge": "Bronze",
+            "title": "Path",
+            "format": "uri"
+          },
+          "instruction": {
+            "description": "A short description of rights and obligations. The use of tl;drLegal is recommended.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "examples": [
+              "You are free to share and change, but you must attribute, and share derivations under the same license. See https://tldrlegal.com/license/odc-open-database-license-(odbl) for further information."
+            ],
+            "badge": "Bronze",
+            "title": "Instruction"
+          },
+          "attribution": {
+            "description": "A copyright holder of the data. Must be provided if attribution licenses are used.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "examples": [
+              "© Reiner Lemoine Institut"
+            ],
+            "badge": "Bronze",
+            "title": "Attribution"
+          },
+          "copyrightStatement": {
+            "description": "A link or path that proves that the source or data has the appropriate license. This can be a page number or website imprint.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "examples": [
+              "https://github.com/OpenEnergyPlatform/oemetadata/blob/production/LICENSE.txt"
+            ],
+            "badge": "Bronze",
+            "title": "Copyright Statement"
+          }
+        },
+        "badge": "Bronze",
+        "title": "License"
+      },
+      "badge": "Bronze",
+      "title": "Licenses"
+    }
+  }
+}

--- a/oemetadata/v2/v21/build_source/schemas/meta.json
+++ b/oemetadata/v2/v21/build_source/schemas/meta.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/v2/v20/build_source/schemas/meta.json",
+  "type": "object",
+  "properties": {
+    "metaMetadata": {
+      "description": "An object that describes the metadata themselves, their format, version and license.",
+      "type": "object",
+      "properties": {
+        "metadataVersion": {
+          "description": "Type and version number of the metadata.",
+          "examples": [
+            "OEMetadata-2.0.4"
+          ],
+          "type": [
+            "string",
+            "null"
+          ],
+          "badge": null,
+          "title": "Metadata Version"
+        },
+        "metadataLicense": {
+          "description": "The license of the OEMetadata. ",
+          "type": "object",
+          "properties": {
+            "name": {
+              "description": "The SPDX identifier.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "examples": [
+                "CC0-1.0"
+              ],
+              "badge": null,
+              "title": "License Name"
+            },
+            "title": {
+              "description": "The official (human readable) title of the license.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "examples": [
+                "Creative Commons Zero v1.0 Universal"
+              ],
+              "badge": null,
+              "title": "License Title"
+            },
+            "path": {
+              "description": "A link or path to the license text.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "examples": [
+                "https://creativecommons.org/publicdomain/zero/1.0"
+              ],
+              "badge": null,
+              "title": "License Path",
+              "format": "uri"
+            }
+          },
+          "badge": null,
+          "title": "Metadata License"
+        }
+      },
+      "title": "Meta Metadata",
+      "options": {
+        "hidden": true
+      }
+    }
+  }
+}

--- a/oemetadata/v2/v21/build_source/schemas/provenance.json
+++ b/oemetadata/v2/v21/build_source/schemas/provenance.json
@@ -1,0 +1,118 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/v2/v21/build_source/schemas/provenance.json",
+  "type": "object",
+  "properties": {
+    "contributors": {
+      "description": "An array of objects of contributors and contributions to the data or metadata.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "description": "A full name of the contributor.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "examples": [
+              "Ludwig Hülk"
+            ],
+            "badge": "Bronze",
+            "title": "Contributor Title"
+          },
+          "path": {
+            "description": "A qualified link or path pointing to a relevant location online for the contributor. This can be the GitHub page or ORCID.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "examples": [
+              "https://github.com/Ludee"
+            ],
+            "badge": "Bronze",
+            "title": "Path"
+          },
+          "organization": {
+            "description": "A string describing the organization this contributor is affiliated to. This can be relevant for the copyright.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "examples": [
+              "Reiner Lemoine Institut"
+            ],
+            "badge": "Bronze",
+            "title": "Organization"
+          },
+          "roles": {
+            "description": "An array describing the roles of the contributor.",
+            "type": "array",
+            "items": {
+              "description": "A role is recommended to follow an established vocabulary: DataCite Metadata Schema’s contributorRole. Useful roles to indicate are: DataCollector, ContactPerson, and DataCurator.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "examples": [
+                "DataCollector",
+                "DataCurator"
+              ],
+              "badge": "Bronze",
+              "title": "Role"
+            },
+            "badge": "Bronze",
+            "title": "Roles"
+          },
+          "date": {
+            "description": "The date of the contribution. Date Format is ISO 8601.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "examples": [
+              "2024-10-21"
+            ],
+            "badge": "Bronze",
+            "title": "Date",
+            "format": "date"
+          },
+          "object": {
+            "description": "The object of the contribution. Which part of the package was supplied or changed.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "examples": [
+              "data and metadata"
+            ],
+            "badge": "Bronze",
+            "title": "Object"
+          },
+          "comment": {
+            "description": "A free-text commentary on what has been done.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "examples": [
+              "Add metadata example."
+            ],
+            "badge": "Bronze",
+            "title": "Comment"
+          },
+          "required": [
+            "title"
+          ]
+        },
+        "badge": "Bronze",
+        "title": "Contributor"
+      },
+      "badge": "Bronze",
+      "title": "Contributors"
+    }
+  },
+  "required": [
+    "contributors"
+  ]
+}

--- a/oemetadata/v2/v21/build_source/schemas/review.json
+++ b/oemetadata/v2/v21/build_source/schemas/review.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/v2/v20/build_source/schemas/review.json",
+  "type": "object",
+  "properties": {
+    "review": {
+      "description": "The metadata on the OEP can go through an open peer review process. See the Academy course [Open Peer Review](https://openenergyplatform.github.io/academy/courses/09_peer_review/) for further information.",
+      "type": "object",
+      "properties": {
+        "path": {
+          "description": "A link or path to the documented open peer review.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "examples": [
+            "https://openenergyplatform.org/dataedit/view/model_draft/oep_table_example/open_peer_review/"
+          ],
+          "badge": null,
+          "title": "Path",
+          "format": "uri"
+        },
+        "badge": {
+          "description": "A badge of either Iron, Bronze, Silver, Gold or Platinum is used to label the quality of the metadata.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "examples": [
+            "Platinum"
+          ],
+          "badge": null,
+          "title": "Badge"
+        }
+      },
+      "title": "Review",
+      "options": {
+        "hidden": true
+      }
+    }
+  }
+}

--- a/oemetadata/v2/v21/build_source/schemas/sources.json
+++ b/oemetadata/v2/v21/build_source/schemas/sources.json
@@ -1,0 +1,175 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/v2/v20/build_source/schemas/sources.json",
+  "type": "object",
+  "properties": {
+    "sources": {
+      "description": "An array of objects with the used and underlying sources of the data and metadata.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "description": "A human readable title of the source, a document title or organisation name.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "examples": [
+              "IPCC Sixth Assessment Report (AR6) - Climate Change 2023 - Synthesis Report"
+            ],
+            "badge": "Bronze",
+            "title": "Source Title"
+          },
+          "authors": {
+            "description": "An array of the full names of the authors of the source material.",
+            "type": "array",
+            "items": {
+              "description": "The authors of the source.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "examples": [
+                "Hoesung Lee",
+                "José Romero",
+                "The Core Writing Team"
+              ],
+              "badge": "Bronze",
+              "title": "Author"
+            },
+            "badge": "Bronze",
+            "title": "Authors"
+          },
+          "description": {
+            "description": "A free text description of the source.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "examples": [
+              "A Report of the Intergovernmental Panel on Climate Change."
+            ],
+            "badge": "Bronze",
+            "title": "Source Description"
+          },
+          "publicationYear": {
+            "description": "Indicates the year when the work was published.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "examples": [
+              "2023"
+            ],
+            "badge": "Bronze",
+            "title": "Publication Year"
+          },
+          "path": {
+            "description": "A DOI or link to the original source.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "examples": [
+              "https://www.ipcc.ch/report/ar6/syr/downloads/report/IPCC_AR6_SYR_FullVolume.pdf"
+            ],
+            "badge": "Bronze",
+            "title": "DOI",
+            "format": "uri"
+          },
+          "sourceLicenses": {
+            "type": "array",
+            "items": {
+              "description": "An array of objects of licenses under which the described source is provided. See https://openenergyplatform.github.io/academy/courses/08_licensing/ for further information.",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "description": "The SPDX identifier.",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "examples": [
+                    "CC-BY-4.0"
+                  ],
+                  "badge": "Bronze",
+                  "title": "Name"
+                },
+                "title": {
+                  "description": "The official (human readable) title of the license.",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "examples": [
+                    "Creative Commons Attribution 4.0 International"
+                  ],
+                  "badge": "Bronze",
+                  "title": "Title"
+                },
+                "path": {
+                  "description": "A link or path to the license text.",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "examples": [
+                    "https://creativecommons.org/licenses/by/4.0/legalcode"
+                  ],
+                  "badge": "Bronze",
+                  "title": "License Identifier",
+                  "format": "uri"
+                },
+                "instruction": {
+                  "description": "A short description of rights and obligations. The use of tl;drLegal is recommended.",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "examples": [
+                    "You are free to share and change, but you must attribute. See https://www.tldrlegal.com/license/creative-commons-attribution-4-0-international-cc-by-4 for further information."
+                  ],
+                  "badge": "Bronze",
+                  "title": "Instruction"
+                },
+                "attribution": {
+                  "description": "A copyright owner of the source. Must be provided if attribution licenses are used.",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "examples": [
+                    "© Intergovernmental Panel on Climate Change 2023"
+                  ],
+                  "badge": "Bronze",
+                  "title": "Attribution"
+                },
+                "copyrightStatement": {
+                  "description": "A link or path that proves that the source or data has the appropriate license. This can be a page number or website imprint.",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "examples": [
+                    "https://www.ipcc.ch/copyright/"
+                  ],
+                  "badge": "Bronze",
+                  "title": "Copyright Statement"
+                }
+              },
+              "badge": "Bronze",
+              "title": "Licenses"
+            },
+            "badge": "Bronze",
+            "title": "Licenses"
+          }
+        },
+        "badge": "Bronze",
+        "title": "Sources"
+      },
+      "badge": "Bronze",
+      "title": "Sources"
+    }
+  }
+}

--- a/oemetadata/v2/v21/build_source/schemas/spatial.json
+++ b/oemetadata/v2/v21/build_source/schemas/spatial.json
@@ -1,0 +1,157 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/v2/v20/build_source/schemas/spatial.json",
+  "type": "object",
+  "properties": {
+    "spatial": {
+      "description": "An object that describes the spatial context of the data.",
+      "type": "object",
+      "properties": {
+        "location": {
+          "description": "An object that describes a covered area or region.",
+          "type": "object",
+          "properties": {
+            "address": {
+              "description": "An address of the location of the data. May be specified with street name, house number, zip code, and city name.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "examples": [
+                "Rudower Chaussee 12, 12489 Berlin"
+              ],
+              "badge": "Silver",
+              "title": "Address"
+            },
+            "@id": {
+              "description": "A path or URI to a specific location. It can use Wikidata or OpenStreetMap.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "examples": [
+                "https://www.wikidata.org/wiki/Q77077223"
+              ],
+              "badge": "Platinum",
+              "title": "Address Identifier"
+            },
+            "latitude": {
+              "description": "The latitude (lat) information of the location. Specifies the north / south position of the geometry.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "examples": [
+                "52.432822"
+              ],
+              "badge": "Gold",
+              "title": "Latitude"
+            },
+            "longitude": {
+              "description": "The longitude (lon) information of the location. Specifies the east / west position of the geometry.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "examples": [
+                "13.5351004"
+              ],
+              "badge": "Gold",
+              "title": "Longitude"
+            }
+          },
+          "badge": "Silver",
+          "title": "Location"
+        },
+        "extent": {
+          "description": "An object that describes a covered area or region.",
+          "type": "object",
+          "properties": {
+            "name": {
+              "description": "The name of the region.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "examples": [
+                "Berlin"
+              ],
+              "badge": "Silver",
+              "title": "Extent Name"
+            },
+            "@id": {
+              "description": "A URI reference for the region.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "examples": [
+                "https://www.wikidata.org/wiki/Q64"
+              ],
+              "format": "uri",
+              "badge": "Platinum",
+              "title": "Extent Identifier"
+            },
+            "resolutionValue": {
+              "description": "The value of the spatial resolution.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "examples": [
+                "100"
+              ],
+              "badge": "Silver",
+              "title": "Spatial Resolution Value"
+            },
+            "resolutionUnit": {
+              "description": "The unit of the spatial resolution.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "examples": [
+                "m"
+              ],
+              "badge": "Silver",
+              "title": "Spatial Resolution Unit"
+            },
+            "boundingBox": {
+              "description": "The covered area specified by the coordinates of a bounding box. The format is [minLon, minLat, maxLon, maxLat] or [W,S,E,N].",
+              "type": "array",
+              "examples": [
+                13.08825,
+                52.33859,
+                13.76104,
+                52.6754
+              ],
+              "items": {
+                "type": "number"
+              },
+              "minItems": 4,
+              "maxItems": 4,
+              "badge": "Gold",
+              "title": "Bounding Box"
+            },
+            "crs": {
+              "description": "The Coordinate Reference System, specified as an EPSG code.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "examples": [
+                "EPSG:4326"
+              ],
+              "badge": "Gold",
+              "title": " Coordinate Reference System (CRS)"
+            }
+          },
+          "badge": "Silver",
+          "title": "Extent"
+        }
+      },
+      "badge": "Silver",
+      "title": "Spatial"
+    }
+  }
+}

--- a/oemetadata/v2/v21/build_source/schemas/temporal.json
+++ b/oemetadata/v2/v21/build_source/schemas/temporal.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/v2/v20/build_source/schemas/temporal.json",
+  "type": "object",
+  "properties": {
+    "temporal": {
+      "description": "An object with the time period covered in the data. Temporal information should contain a \"referenceDate\" or the keys that describe a time series, or both.",
+      "type": "object",
+      "properties": {
+        "referenceDate": {
+          "description": "A base year, month or day. The time for which the data should be accurate. Date Format is ISO 8601.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "examples": [
+            "2020-01-01"
+          ],
+          "badge": "Silver",
+          "title": "Reference Date",
+          "format": "date"
+        },
+        "timeseries": {
+          "description": "An array that describe the timeseries.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "start": {
+                "description": "The start time of a time series.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "examples": [
+                  "2020-01-01T00:00:00+01:00"
+                ],
+                "badge": "Silver",
+                "title": "Timeseries Start",
+                "format": "date-time"
+              },
+              "end": {
+                "description": "The temporal end point of a time series.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "examples": [
+                  "2020-01-01T23:59:30+01:00"
+                ],
+                "badge": "Silver",
+                "title": "Timeseries End",
+                "format": "date-time"
+              },
+              "resolutionValue": {
+                "description": "The time span between individual information points in a time series. The value of the resolution.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "examples": [
+                  "15"
+                ],
+                "badge": "Silver",
+                "title": "Timeseries Resolution Value"
+              },
+              "resolutionUnit": {
+                "description": "The unit of the temporal resolution.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "examples": [
+                  "min"
+                ],
+                "badge": "Silver",
+                "title": "Timeseries Resolution Unit"
+              },
+              "alignment": {
+                "description": "An indicator of whether timestamps in a time series are to the left, right or in the centre.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "examples": [
+                  "left"
+                ],
+                "badge": "Gold",
+                "title": "Timeseries Alignment"
+              },
+              "aggregationType": {
+                "description": "An indicator of whether the values are a sum, an average or a current value.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "examples": [
+                  "current"
+                ],
+                "badge": "Gold",
+                "title": "Timeseries Aggregation Type"
+              }
+            },
+            "badge": "Silver",
+            "title": "Timeseries"
+          },
+          "badge": "Silver",
+          "title": "Timeseries"
+        }
+      },
+      "badge": "Silver",
+      "title": "Temporal"
+    }
+  }
+}

--- a/oemetadata/v2/v21/build_source/scripts/create_example.py
+++ b/oemetadata/v2/v21/build_source/scripts/create_example.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2024 Ludwig Hülk <@Ludee> © Reiner Lemoine Institut
+# SPDX-FileCopyrightText: 2024 Jonas Huber <jh-RLI> © Reiner Lemoine Institut
+# SPDX-FileCopyrightText: oemetadata <https://github.com/OpenEnergyPlatform/oemetadata/>
+# SPDX-License-Identifier: MIT
+
+"""
+Title: Create example from schema
+Description: Create example.json from schema.json
+Author: jh-RLI, Ludee
+Email: jonas.huber@rl-institut.de
+Date: 2024-05-30
+Version: 1.0.0
+"""
+
+# Import
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Union
+
+from settings import (
+    EXAMPLE_PATH,
+    LOG_FORMAT,
+    RESOLVED_SCHEMA_FILE_NAME,
+    SCHEMA_EXAMPLE_FIELDS,
+    SCHEMA_EXAMPLE_PROV,
+)
+
+
+# Configuration
+logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
+logger = logging.getLogger(__name__)
+
+
+def read_schema(filepath: str) -> Dict[str, Any]:
+    """Read a JSON schema from a file.
+
+    Args:
+        filepath (str): The path to the JSON schema file.
+
+    Returns:
+        Dict[str, Any]: The JSON schema as a dictionary.
+    """
+
+    with open(filepath, encoding="utf-8") as file:
+        schema = json.load(file)
+    logger.info(f"Processing schema: {schema}")
+    return schema
+
+
+def read_metadata_schema(filepath: str) -> Dict[str, Any]:
+    """Read a JSON schema from a file.
+
+    Args:
+        filepath (str): The path to the JSON schema file.
+
+    Returns:
+        Dict[str, Any]: The JSON schema as a dictionary.
+    """
+    if not os.path.exists(filepath):
+        raise FileNotFoundError(f"Error: File '{filepath}' does not exist.")
+
+    try:
+        with open(filepath, encoding="utf-8") as file:
+            schema = json.load(file)
+
+        # Basic validation of schema structure
+        if not isinstance(schema, dict):
+            print("Error: Schema is not a dictionary. Check the schema format.")
+            return {}
+
+        logger.info(f"Schema loaded successfully from {filepath}")
+        logger.info(f"Schema top-level keys: {list(schema.keys())}")
+
+        # Additional debugging info: Check expected keys
+        if "$schema" not in schema or "type" not in schema:
+            logger.warning("Schema may be missing key fields like '$schema' or 'type'.")
+
+        logger.info(
+            f"Full schema content (trimmed for large files): {str(schema)[:500]}..."
+        )
+
+        return schema
+
+    except json.JSONDecodeError as e:
+        raise Exception(f"Error reading JSON: {e}")
+    except Exception as e:
+        raise Exception(f"An unexpected error occurred while reading the schema: {e}")
+
+
+# def generate_example_old(
+#     schema: Dict[str, Any]
+# ) -> Union[Dict[str, Any], List[Any], str, None]:
+#     """Generate a JSON object from the schema using the
+#     example values provided.
+#
+#     Args:
+#         schema (Dict[str, Any]): The JSON schema.
+#
+#     Returns:
+#         Union[Dict[str, Any], List[Any], str, None]:
+#             A JSON object generated from the schema.
+#     """
+#     if "examples" in schema:
+#         return schema["examples"]
+#
+#     schema_type = schema.get("type", None)
+#     if isinstance(schema_type, list):
+#         schema_type = schema_type[0]
+#
+#     if schema_type == "object":
+#         example_object = {}
+#         properties = schema.get("properties", {})
+#         for key, value in properties.items():
+#             example_object[key] = generate_example(value)
+#         return example_object
+#
+#     elif schema_type == "array":
+#         items = schema.get("items", {})
+#
+#         # Fix: Avoid double-wrapping by checking if the generated
+#         # example is already a list
+#         example = generate_example(items)
+#
+#         if isinstance(example, list):
+#             return example  # If it's already a list, return it directly
+#         else:
+#             return [example]  # Otherwise, wrap it in a list
+#
+#     elif schema_type == "string":
+#         return ""
+#
+#     elif schema_type == "null":
+#         return None
+#
+#     return None
+
+
+def extract_examples_from_schema(
+    schema: Dict[str, Any],
+) -> Union[Dict[str, Any], List[Any], str, None]:
+    """Generate a valid example from the schema using the provided example values."""
+
+    # If the schema has an "examples" field, handle it appropriately
+    if "examples" in schema:
+        examples = schema["examples"]
+        if isinstance(examples, list):
+            # Return a single value if the list contains one item
+            if len(examples) == 1:
+                return examples[0]
+            return examples  # If multiple items, return the whole list
+        return examples  # If it's a single item, return the value
+
+    # If the schema type is an object, process each property recursively
+    schema_type = schema.get("type")
+    if isinstance(schema_type, list):
+        schema_type = schema_type[0]
+
+    if schema_type == "object":
+        example_object = {}
+        properties = schema.get("properties", {})
+        for key, value in properties.items():
+            example_object[key] = extract_examples_from_schema(value)
+        return example_object
+
+    # If the schema type is an array, process the items recursively
+    elif schema_type == "array":
+        items = schema.get("items", {})
+        example = extract_examples_from_schema(items)
+        return [example] if not isinstance(example, list) else example
+
+    # Handle basic types like string, number, boolean, null
+    elif schema_type == "string":
+        return ""  # Example string
+    elif schema_type == "number":
+        return "0"  # Example number
+    elif schema_type == "boolean":
+        return "true"  # Example boolean
+    elif schema_type == "null":
+        return None  # Example null
+
+    # Unsupported schema
+    else:
+        raise ValueError(f"Unsupported schema_type: {schema_type}")
+
+
+def create_json_from_schema(schema_file: str) -> Dict[str, Any]:
+    """Generate a JSON object that conforms to the schema read from a file.
+
+    Args:
+        schema_file (str): The path to the JSON schema file.
+
+    Returns:
+        Dict[str, Any]: A JSON object generated from the schema.
+    """
+    schema = read_metadata_schema(schema_file)
+    print(f"Create JSON from schema: {schema_file}")
+    result = extract_examples_from_schema(schema)
+
+    # Ensure the result is a dictionary
+    if isinstance(result, dict):
+        return result
+    else:
+        return {}  # Return an empty dictionary as a fallback
+
+
+def save_json(data: Dict[str, Any], filename: Path) -> None:
+    """Save the given data as a JSON file.
+
+    Args:
+        data (Dict[str, Any]): The JSON data to be saved.
+        filename (str): The filename where the JSON data will be saved.
+    """
+    with open(filename, "w", encoding="utf-8") as file:
+        json.dump(data, file, indent=2)
+        file.write("\n")
+
+    logger.info(f"example JSON generated and saved to {filename}")
+
+
+def test_oemetadata_schema_should_validate_oemetadata_example(example):
+    from jsonschema import ValidationError, validate
+
+    from oemetadata.v2.v20.schema import OEMETADATA_V20_SCHEMA
+
+    try:
+        validate(example, OEMETADATA_V20_SCHEMA)
+        logger.info("OEMetadata Example is valid OEMetadata Schema (v2.0).")
+    except ValidationError as e:
+        logger.info("Cannot validate OEMetadata Example with Schema (v2.0)!", e)
+
+
+def find_and_replace_key(data, target_key, new_value):
+    if isinstance(data, dict):
+        for key, value in data.items():
+            if key == target_key:
+                data[key] = new_value
+                return True  # Return True if replacement is successful
+            elif isinstance(value, (dict, list)):
+                if find_and_replace_key(value, target_key, new_value):
+                    return True  # Return True if replacement occurs in nested structure
+    elif isinstance(data, list):
+        for item in data:
+            if find_and_replace_key(item, target_key, new_value):
+                return True
+    return False  # Return False if key not found
+
+
+def replace_key_in_json(file_path, target_key, new_value):
+    # Open and read the JSON file
+    with open(file_path) as file:
+        data = json.load(file)
+
+    # Perform the key replacement
+    if find_and_replace_key(data, target_key, new_value):
+        # Save the updated JSON data back to the file
+        with open(file_path, "w", encoding="utf-8") as file:
+            json.dump(data, file, ensure_ascii=False, indent=2)
+            file.write("\n")
+        logger.info(f"Updated '{target_key}' to '{new_value}' in {file_path}")
+    else:
+        logger.info(f"Key '{target_key}' not found in JSON file.")
+
+
+if __name__ == "__main__":
+    logger.info("Create OEMetadata Example from Schema.")
+    schema_filename = RESOLVED_SCHEMA_FILE_NAME
+    json_data = create_json_from_schema(schema_filename)
+    save_json(json_data, EXAMPLE_PATH)
+    logger.info("OEMetadata Example created!")
+    example_fields = read_schema(SCHEMA_EXAMPLE_FIELDS)
+    replace_key_in_json(EXAMPLE_PATH, "fields", example_fields)
+    example_contributors = read_schema(SCHEMA_EXAMPLE_PROV)
+    replace_key_in_json(EXAMPLE_PATH, "contributors", example_contributors)
+    test_oemetadata_schema_should_validate_oemetadata_example(json_data)

--- a/oemetadata/v2/v21/build_source/scripts/create_latest.py
+++ b/oemetadata/v2/v21/build_source/scripts/create_latest.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2025 Ludwig Hülk <@Ludee> © Reiner Lemoine Institut
+# SPDX-FileCopyrightText: 2025 Jonas Huber <jh-RLI> © Reiner Lemoine Institut
+# SPDX-FileCopyrightText: oemetadata <https://github.com/OpenEnergyPlatform/oemetadata/>
+# SPDX-License-Identifier: MIT
+
+"""
+Title: Create latest folder
+Description: Copy the current version to the latest folder
+"""
+
+# Import
+import logging
+import os
+import re
+import shutil
+
+from settings import LATEST_PATH, LOG_FORMAT, VERSION_PATH
+
+
+# Configuration
+logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
+logger = logging.getLogger(__name__)
+
+
+def clear_latest_folder():
+    """Delete latest folder and recreate latest folder."""
+    if os.path.exists(LATEST_PATH):
+        shutil.rmtree(LATEST_PATH)
+    os.makedirs(LATEST_PATH)
+    logger.info(f"Clear latest folder: {LATEST_PATH}")
+
+
+def copy_current_version(source_files):
+    """Copies selected files into latest folder."""
+    if os.path.exists(LATEST_PATH):
+        for file in source_files:
+            shutil.copy(VERSION_PATH / file, LATEST_PATH)
+        shutil.copy(VERSION_PATH / "example.json", LATEST_PATH)
+        shutil.copy(VERSION_PATH / "example.py", LATEST_PATH)
+        shutil.copy(VERSION_PATH / "metadata_key_description.md", LATEST_PATH)
+        shutil.copy(VERSION_PATH / "README.md", LATEST_PATH)
+        shutil.copy(VERSION_PATH / "schema.json", LATEST_PATH)
+        shutil.copy(VERSION_PATH / "schema.py", LATEST_PATH)
+        shutil.copy(VERSION_PATH / "template.json", LATEST_PATH)
+        shutil.copy(VERSION_PATH / "template.py", LATEST_PATH)
+    logger.info("Copy files to latest folder.")
+
+
+def replace_in_files(pattern, replacement):
+    """Replaces pattern in all files within latest folder."""
+    folder = LATEST_PATH
+    for filename in os.listdir(folder):
+        file_path = os.path.join(folder, filename)
+        if os.path.isfile(file_path):
+            with open(file_path, encoding="utf-8") as f:
+                content = f.read()
+            content = re.sub(pattern, replacement, content)
+            with open(file_path, "w", encoding="utf-8") as f:
+                f.write(content)
+    logger.info(f"Replace {pattern} with {replacement}.")
+
+
+if __name__ == "__main__":
+    logger.info("Create OEMetadata latest version.")
+    clear_latest_folder()
+    files = {
+        "context.json",
+        "example.json",
+        "example.py",
+        "metadata_key_description.md",
+        "README.md",
+        "schema.json",
+        "schema.py",
+        "template.json",
+        "template.py",
+        "__init__.py",
+    }
+    copy_current_version(files)
+    replace_in_files("v2/v20", "latest")
+    replace_in_files("V20", "LATEST")
+    logger.info("OEMetadata latest version created!")

--- a/oemetadata/v2/v21/build_source/scripts/create_schema.py
+++ b/oemetadata/v2/v21/build_source/scripts/create_schema.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2024 Ludwig Hülk <@Ludee> © Reiner Lemoine Institut
+# SPDX-FileCopyrightText: 2024 Jonas Huber <jh-RLI> © Reiner Lemoine Institut
+# SPDX-FileCopyrightText: oemetadata <https://github.com/OpenEnergyPlatform/oemetadata/>
+# SPDX-License-Identifier: MIT
+
+"""
+Title: Create OEMetadata schema from schemas
+Description: Resolve "$ref" elements in schema.json
+Author: jh-RLI, Ludee
+Email: jonas.huber@rl-institut.de
+Date: 2024-05-30
+Version: 1.0.0
+
+requires: "pip install jsonschema referencing"
+
+Usage: Script with additional arguments --debug for more detailed output.
+        Requires the folder structure introduced in OEMetadata v2.0.1.
+"""
+
+# Standard Library Imports
+# import os
+import argparse
+import json
+import logging
+import sys
+
+# from datetime import datetime
+from urllib.parse import urljoin
+
+from jsonschema import Draft202012Validator
+from referencing import Registry, Resource
+from settings import (
+    EXPECTED_SCHEMA_PATH,
+    LOG_FORMAT,
+    MAIN_SCHEMA_PATH,
+    RESOLVED_SCHEMA_FILE_NAME,
+    SCHEMA_REFS,
+)
+
+
+# Configuration
+
+logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
+logger = logging.getLogger(__name__)
+
+
+# Function Definitions
+def setup():
+    """
+    Setup function to initialize resources or configurations.
+    """
+    logger.info("Setup complete.")
+
+
+# Load the main schema
+def load_schema(schema_path):
+    with open(schema_path, encoding="utf-8") as file:
+        return json.load(file)
+
+
+# Ensure the schema has the $schema field
+def ensure_schema_field(schema):
+    if "$schema" not in schema:
+        schema["$schema"] = "https://json-schema.org/draft/2020-12/schema"
+    return schema
+
+
+# Debugging function to print registry contents
+def print_registry_contents(registry, debug):
+    if debug:
+        print("Registry Contents:")
+        for uri, resource in registry._resources.items():
+            print(f"{uri}: {resource.contents}")
+
+
+# Resolve and merge references using referencing library
+def resolve_and_merge(schema_path, debug):
+    schema = load_schema(schema_path)
+    schema = ensure_schema_field(schema)
+
+    # Create a registry and register the schemas
+    base_uri = MAIN_SCHEMA_PATH.resolve().parent.as_uri() + "/"
+    registry = Registry().with_resource(base_uri, Resource.from_contents(schema))
+
+    for schema_file in SCHEMA_REFS.glob("*.json"):
+        try:
+            with open(schema_file, encoding="utf-8") as file:
+                ref_schema = json.load(file)
+                ref_schema = ensure_schema_field(ref_schema)
+                schema_uri = urljoin(base_uri, schema_file.name)
+                registry = registry.with_resource(
+                    schema_uri, Resource.from_contents(ref_schema)
+                )
+        except json.JSONDecodeError as e:
+            logger.error(f"Error decoding JSON from {schema_file}: {e}")
+            continue
+
+    # Print registry contents for debugging
+    print_registry_contents(registry, debug)
+
+    # Resolve references in the schema
+    def resolve_references(schema, registry, base_uri):
+        if isinstance(schema, dict):
+            if "$ref" in schema:
+                ref_uri = urljoin(base_uri, schema["$ref"])
+                if debug:
+                    print(f"Resolving reference {ref_uri}")  # Debugging
+                try:
+                    ref_schema = registry[ref_uri]
+                    if debug:
+                        print(
+                            f"Resolved reference {ref_uri} to {ref_schema.contents}"
+                        )  # Debugging
+                    return ref_schema.contents[
+                        "properties"
+                    ]  # Return only the properties
+                except KeyError as e:
+                    raise ValueError(f"Reference {ref_uri} could not be resolved: {e}")
+            else:
+                return {
+                    key: resolve_references(value, registry, base_uri)
+                    for key, value in schema.items()
+                }
+        elif isinstance(schema, list):
+            return [resolve_references(item, registry, base_uri) for item in schema]
+        return schema
+
+    # Resolve the top-level properties
+    def resolve_top_level_properties(schema, registry, base_uri):
+        resolved_properties = {}
+        for prop, value in schema["properties"].items():
+            if isinstance(value, dict) and "properties" in value:
+                resolved_value = resolve_references(
+                    value["properties"], registry, base_uri
+                )
+                resolved_properties[prop] = resolved_value
+            else:
+                resolved_value = resolve_references(value, registry, base_uri)
+                for i, v in resolved_value.items():
+                    if isinstance(v, dict) and i != "items":
+                        resolved_properties[i] = v
+
+                    elif prop == "resources":
+                        resolved_value = resolve_references(value, registry, base_uri)
+                        resources = {}
+                        for _k, _v in resolved_value["items"].items():
+                            if isinstance(_v, dict):
+                                # Update all values instead of key:values to
+                                # avoid adding schema_structure.json wrapper
+                                # objects
+                                for element in _v.values():
+                                    resources.update(element)
+                        resolved_properties[prop] = resolved_value
+                        # Patch the missing keys
+                        resolved_properties[prop]["items"] = {
+                            "type": "object",
+                            "properties": {**resources},
+                        }
+
+                    else:
+                        resolved_properties[prop] = resolved_value
+        return resolved_properties
+
+    schema["properties"] = resolve_top_level_properties(schema, registry, base_uri)
+    return schema
+
+
+def validate_schema(resolved_schema, expected_schema):
+    validator = Draft202012Validator(expected_schema)
+    errors = sorted(validator.iter_errors(resolved_schema), key=lambda e: e.path)
+    for error in errors:
+        print(f"Validation error at {list(error.path)}: {error.message}")
+
+
+# Load expected schema (without refs) for validation
+def load_expected_schema(expected_schema_path):
+    with open(expected_schema_path, encoding="utf-8") as file:
+        return json.load(file)
+
+
+def main(debug):
+    """
+    Main function to execute the script's primary logic.
+    """
+    try:
+        setup()
+        logger.info("Main execution started.")
+
+        # Resolve and merge the schema
+        resolved_schema = resolve_and_merge(MAIN_SCHEMA_PATH, debug)
+
+        # Save the resolved schema to a new file
+        with open(RESOLVED_SCHEMA_FILE_NAME, "w", encoding="utf-8") as output_file:
+            json.dump(resolved_schema, output_file, ensure_ascii=False, indent=2)
+            output_file.write("\n")
+
+        # Load the expected schema and validate
+        expected_schema = load_expected_schema(EXPECTED_SCHEMA_PATH)
+        validate_schema(resolved_schema, expected_schema)
+
+        logger.info("Main execution finished.")
+    except Exception as e:
+        logger.error("An error occurred: %s", e)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Resolve and merge JSON schema references."
+    )
+    parser.add_argument("--debug", action="store_true", help="Enable debugging output")
+    args = parser.parse_args()
+
+    main(args.debug)

--- a/oemetadata/v2/v21/build_source/scripts/create_template.py
+++ b/oemetadata/v2/v21/build_source/scripts/create_template.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: 2024 Ludwig Hülk <@Ludee> © Reiner Lemoine Institut
+# SPDX-FileCopyrightText: 2024 Jonas Huber <jh-RLI> © Reiner Lemoine Institut
+# SPDX-FileCopyrightText: oemetadata <https://github.com/OpenEnergyPlatform/oemetadata/>
+# SPDX-License-Identifier: MIT
+
+"""
+Title: Create template from schema
+Description: Create template.json from schema.json.
+Author: jh-RLI, Ludee
+Email: jonas.huber@rl-institut.de
+Date: 2024-05-30
+Version: 1.0.0
+"""
+
+# Import
+
+import json
+import logging
+
+from settings import LOG_FORMAT, RESOLVED_SCHEMA_FILE_NAME, TEMPLATE_PATH
+
+
+# Configuration
+
+logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
+logger = logging.getLogger(__name__)
+
+
+def generate_template(schema):
+    if isinstance(schema, bool):
+        return {} if schema else None
+
+    if "type" not in schema and "properties" not in schema and "items" not in schema:
+        return None
+
+    schema_type = schema.get("type")
+
+    if isinstance(schema_type, list):
+        schema_type = schema_type[0]
+
+    template = None
+    # Convert template string to actual type if necessary
+    # if schema_type == "array" and isinstance(template, str):
+    #     try:
+    #         template = json.loads(template.replace("'", '"'))
+    #     except json.JSONDecodeError:
+    #         pass
+    # return template
+
+    if schema_type == "object" or "properties" in schema:
+        template = {}
+        properties = schema.get("properties", {})
+        for prop, prop_schema in properties.items():
+            template[prop] = generate_template(prop_schema)
+        additional_properties = schema.get("additionalProperties", True)
+        if isinstance(additional_properties, dict):
+            template["additional_property"] = generate_template(additional_properties)
+        return template
+
+    if schema_type == "array":
+        item_schema = schema.get("items", {})
+        return [generate_template(item_schema)]
+
+    if schema_type == "string":
+        return ""
+
+    if schema_type == "number":
+        return 0
+
+    if schema_type == "integer":
+        return 0
+
+    if schema_type == "boolean":
+        return False
+
+    return None
+
+
+def main():
+    schema_file_path = RESOLVED_SCHEMA_FILE_NAME
+
+    with open(schema_file_path, encoding="utf-8") as schema_file:
+        schema = json.load(schema_file)
+
+    template = generate_template(schema)
+
+    template_file_path = TEMPLATE_PATH
+    with open(template_file_path, "w", encoding="utf-8") as template_file:
+        json.dump(template, template_file, indent=2, ensure_ascii=False)
+
+    logger.info(f"template JSON generated and saved to {template_file_path}")
+
+    # WARNING: The metaMetadata is missing and the boundingBox is wrong!
+
+
+def test_oemetadata_schema_should_validate_oemetadata_template():
+    from jsonschema import ValidationError, validate
+
+    from oemetadata.v2.v20.schema import OEMETADATA_V20_SCHEMA
+    from oemetadata.v2.v20.template import OEMETADATA_V20_TEMPLATE
+
+    try:
+        validate(OEMETADATA_V20_TEMPLATE, OEMETADATA_V20_SCHEMA)
+        print("OEMetadata Template is valid OEMetadata Schema (v2.0).")
+    except ValidationError as e:
+        print("Cannot validate OEMetadata Template with Schema (v2.0)!", e)
+
+
+def find_and_replace_key(data, target_key, new_value):
+    if isinstance(data, dict):
+        for key, value in data.items():
+            if key == target_key:
+                data[key] = new_value
+                return True  # Return True if replacement is successful
+            elif isinstance(value, (dict, list)):
+                if find_and_replace_key(value, target_key, new_value):
+                    return True  # Return True if replacement occurs in nested structure
+    elif isinstance(data, list):
+        for item in data:
+            if find_and_replace_key(item, target_key, new_value):
+                return True
+    return False  # Return False if key not found
+
+
+def replace_key_in_json(file_path, target_key, new_value):
+    # Open and read the JSON file
+    with open(file_path) as file:
+        data = json.load(file)
+
+    # Perform the key replacement
+    if find_and_replace_key(data, target_key, new_value):
+        # Save the updated JSON data back to the file
+        with open(file_path, "w") as file:
+            json.dump(data, file, indent=2)
+            file.write("\n")
+        print(f"Updated '{target_key}' to '{new_value}' in {file_path}")
+    else:
+        print(f"Key '{target_key}' not found in JSON file.")
+
+
+if __name__ == "__main__":
+    logger.info("Generation started.")
+    main()
+    replace_key_in_json(TEMPLATE_PATH, "boundingBox", [0, 0, 0, 0])
+    replace_key_in_json(TEMPLATE_PATH, "metadataVersion", "OEMetadata-2.0.4")
+    replace_key_in_json(
+        TEMPLATE_PATH,
+        "metadataLicense",
+        {
+            "name": "CC0-1.0",
+            "title": "Creative Commons Zero v1.0 Universal",
+            "path": "https://creativecommons.org/publicdomain/zero/1.0",
+        },
+    )
+    test_oemetadata_schema_should_validate_oemetadata_template()
+    logger.info("Generation ended.")

--- a/oemetadata/v2/v21/build_source/scripts/example/contributors.json
+++ b/oemetadata/v2/v21/build_source/scripts/example/contributors.json
@@ -1,0 +1,24 @@
+[
+  {
+    "title": "Ludwig Hülk",
+    "path": "https://github.com/Ludee",
+    "organization": "Reiner Lemoine Institut",
+    "roles": [
+      "DataCollector"
+    ],
+    "date": "2024-11-19",
+    "object": "data",
+    "comment": "Date of data creation"
+  },
+  {
+    "title": "Ludwig Hülk",
+    "path": "https://github.com/Ludee",
+    "organization": "Reiner Lemoine Institut",
+    "roles": [
+      "DataCurator"
+    ],
+    "date": "2024-11-30",
+    "object": "metadata",
+    "comment": "Date of metadata creation"
+  }
+]

--- a/oemetadata/v2/v21/build_source/scripts/example/contributors.json.license
+++ b/oemetadata/v2/v21/build_source/scripts/example/contributors.json.license
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2024 Ludwig Hülk <@Ludee> © Reiner Lemoine Institut
+# SPDX-FileCopyrightText: 2024 Jonas Huber <jh-RLI> © Reiner Lemoine Institut
+# SPDX-FileCopyrightText: oemetadata <https://github.com/OpenEnergyPlatform/oemetadata/>
+# SPDX-License-Identifier: MIT

--- a/oemetadata/v2/v21/build_source/scripts/example/fields.json
+++ b/oemetadata/v2/v21/build_source/scripts/example/fields.json
@@ -1,0 +1,167 @@
+[
+  {
+    "name": "id",
+    "description": "Unique identifier",
+    "type": "serial",
+    "nullable": false,
+    "unit": null,
+    "isAbout": [
+      {
+        "name": "identifier",
+        "@id": "http://purl.obolibrary.org/obo/IAO_0020000"
+      }
+    ],
+    "valueReference": [
+      {
+        "value": null,
+        "name": null,
+        "@id": null
+      }
+    ]
+  },
+  {
+    "name": "name",
+    "description": "Technology Name",
+    "type": "text",
+    "nullable": true,
+    "unit": null,
+    "isAbout": [
+      {
+        "name": "power generation technology",
+        "@id": "http://openenergy-platform.org/ontology/oeo/OEO_00010423"
+      }
+    ],
+    "valueReference": [
+      {
+        "value": "wind",
+        "name": "wind power technology",
+        "@id": "http://openenergyplatform.org/ontology/oeo/OEO_00010424"
+      }
+    ]
+  },
+  {
+    "name": "type",
+    "description": "Type of wind farm",
+    "type": "text",
+    "nullable": true,
+    "unit": null,
+    "isAbout": [
+      {
+        "name": "wind farm",
+        "@id": "https://openenergyplatform.org/ontology/oeo/OEO_00000447/"
+      }
+    ],
+    "valueReference": [
+      {
+        "value": "onshore",
+        "name": "onshore wind farm",
+        "@id": "https://openenergyplatform.org/ontology/oeo/OEO_00000311/"
+      },
+      {
+        "value": "offshore",
+        "name": "offshore wind farm",
+        "@id": "https://openenergyplatform.org/ontology/oeo/OEO_00000308/"
+      }
+    ]
+  },
+  {
+    "name": "year",
+    "description": "Reference year",
+    "type": "integer",
+    "nullable": true,
+    "unit": null,
+    "isAbout": [
+      {
+        "name": "year",
+        "@id": "https://openenergyplatform.org/ontology/oeo/UO_0000036/"
+      }
+    ],
+    "valueReference": [
+      {
+        "value": null,
+        "name": null,
+        "@id": null
+      }
+    ]
+  },
+  {
+    "name": "value",
+    "description": "Bruttoleistung",
+    "type": "decimal",
+    "nullable": true,
+    "unit": "MW",
+    "isAbout": [
+      {
+        "name": "nameplate capacity",
+        "@id": "https://openenergyplatform.org/ontology/oeo/OEO_00230003/"
+      }
+    ],
+    "valueReference": [
+      {
+        "value": null,
+        "name": null,
+        "@id": null
+      }
+    ]
+  },
+  {
+    "name": "is_active",
+    "description": "Betriebsstatus",
+    "type": "boolean",
+    "nullable": false,
+    "unit": null,
+    "isAbout": [
+      {
+        "name": "Operating Mode Status",
+        "@id": "https://ontology.brickschema.org/brick/Operating_Mode_Status"
+      }
+    ],
+    "valueReference": [
+      {
+        "value": null,
+        "name": null,
+        "@id": null
+      }
+    ]
+  },
+  {
+    "name": "version",
+    "description": "Version",
+    "type": "integer",
+    "nullable": true,
+    "unit": null,
+    "isAbout": [
+      {
+        "name": "version number",
+        "@id": "http://purl.obolibrary.org/obo/IAO_0000129"
+      }
+    ],
+    "valueReference": [
+      {
+        "value": null,
+        "name": null,
+        "@id": null
+      }
+    ]
+  },
+  {
+    "name": "comment",
+    "description": "",
+    "type": "text",
+    "nullable": true,
+    "unit": null,
+    "isAbout": [
+      {
+        "name": "comment",
+        "@id": "http://semanticscience.org/resource/SIO_001167"
+      }
+    ],
+    "valueReference": [
+      {
+        "value": null,
+        "name": null,
+        "@id": null
+      }
+    ]
+  }
+]

--- a/oemetadata/v2/v21/build_source/scripts/example/fields.json.license
+++ b/oemetadata/v2/v21/build_source/scripts/example/fields.json.license
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: 2024 Ludwig Hülk <@Ludee> © Reiner Lemoine Institut
+# SPDX-FileCopyrightText: 2024 Jonas Huber <jh-RLI> © Reiner Lemoine Institut
+# SPDX-FileCopyrightText: oemetadata <https://github.com/OpenEnergyPlatform/oemetadata/>
+# SPDX-License-Identifier: MIT

--- a/oemetadata/v2/v21/build_source/scripts/settings.py
+++ b/oemetadata/v2/v21/build_source/scripts/settings.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2024 Ludwig Hülk <@Ludee> © Reiner Lemoine Institut
+# SPDX-FileCopyrightText: 2024 Jonas Huber <jh-RLI> © Reiner Lemoine Institut
+# SPDX-FileCopyrightText: oemetadata <https://github.com/OpenEnergyPlatform/oemetadata/>
+# SPDX-License-Identifier: MIT
+
+from pathlib import Path
+
+
+LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+
+BASE_PATH = Path("oemetadata/v2/")
+VERSION = "v20"
+VERSION_PATH = BASE_PATH / VERSION
+SCHEMA_BUILD_PATH = VERSION_PATH / "build_source"
+MAIN_SCHEMA_PATH = SCHEMA_BUILD_PATH / "schema_structure.json"
+SCHEMA_REFS = SCHEMA_BUILD_PATH / "schemas"
+SCHEMA_EXAMPLE_FIELDS = SCHEMA_BUILD_PATH / "scripts/example/fields.json"
+SCHEMA_EXAMPLE_PROV = SCHEMA_BUILD_PATH / "scripts/example/contributors.json"
+RESOLVED_SCHEMA_FILE_NAME = VERSION_PATH / "schema.json"
+EXPECTED_SCHEMA_PATH = VERSION_PATH / "schema.json"
+
+EXAMPLE_PATH = VERSION_PATH / "example.json"
+TEMPLATE_PATH = VERSION_PATH / "template.json"
+LATEST_PATH = Path("oemetadata/latest/")

--- a/oemetadata/v2/v21/context.json
+++ b/oemetadata/v2/v21/context.json
@@ -1,0 +1,324 @@
+{
+  "@context": {
+    "adms": "http://www.w3.org/ns/adms#",
+    "cco": "https://terminology.tib.eu/ts/ontologies/cco",
+    "csvw": "http://www.w3.org/ns/csvw#",
+    "dbo": "http://dbpedia.org/ontology/",
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "dcat": "http://www.w3.org/ns/dcat#",
+    "dct": "http://purl.org/dc/terms/",
+    "foaf": "http://xmlns.com/foaf/0.1/",
+    "ncit": "http://purl.obolibrary.org/obo/ncit.owl",
+    "oeo": "https://openenergyplatform.org/ontology/oeo/",
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "prov": "http://www.w3.org/ns/prov#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "sc": "http://schema.org/",
+    "spdx": "http://spdx.org/rdf/terms#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "name": {
+      "@id": "rdfs:label",
+      "@type": "xsd:string"
+    },
+    "title": {
+      "@id": "dct:title",
+      "@type": "xsd:string"
+    },
+    "description": {
+      "@id": "dct:description",
+      "@type": "xsd:string"
+    },
+    "id": {
+      "@id": "dct:identifier",
+      "@type": "xsd:anyURI"
+    },
+    "resources": {
+      "@container": "@set",
+      "@id": "dcat:Dataset"
+    },
+    "topics": {
+      "@container": "@set",
+      "@id": "foaf:topic",
+      "@type": "xsd:string"
+    },
+    "path": {
+      "@id": "dcat:accessURL",
+      "@type": "@id"
+    },
+    "languages": {
+      "@id": "dct:language",
+      "@container": "@set",
+      "@type": "xsd:string"
+    },
+    "subject": {
+      "@container": "@set",
+      "@id": "dct:subject"
+    },
+    "keywords": {
+      "@id": "dcat:keyword",
+      "@container": "@set",
+      "@type": "xsd:string"
+    },
+    "publicationDate": {
+      "@id": "dct:issued",
+      "@type": "xsd:date"
+    },
+    "embargoPeriod": "@nest",
+    "start": {
+      "@id": "dbo:startDateTime",
+      "@type": "xsd:dateTime"
+    },
+    "end": {
+      "@id": "dbo:endDateTime",
+      "@type": "xsd:dateTime"
+    },
+    "isActive": {
+      "@id": "adms:status",
+      "@type": "xsd:boolean"
+    },
+    "context": "@nest",
+    "homepage": {
+      "@id": "foaf:homepage",
+      "@type": "xsd:anyURI"
+    },
+    "documentation": {
+      "@id": "ncit:NCIT_C165054",
+      "@type": "xsd:anyURI"
+    },
+    "sourceCode": {
+      "@id": "oeo:OEO_00000091",
+      "@type": "xsd:anyURI"
+    },
+    "publisher": {
+      "@id": "dct:publisher",
+      "@type": "foaf:Agent"
+    },
+    "publisherLogo": {
+      "@id": "foaf:logo",
+      "@type": "xsd:anyURI"
+    },
+    "contact": {
+      "@id": "oeo:OEO_00000107",
+      "@type": "xsd:string"
+    },
+    "fundingAgency": {
+      "@id": "sc:FundingAgency",
+      "@type": "xsd:string"
+    },
+    "fundingAgencyLogo": {
+      "@id": "foaf:logo",
+      "@type": "xsd:anyURI"
+    },
+    "grantNo": {
+      "@id": "sc:Grant",
+      "@type": "xsd:string"
+    },
+    "spatial": {
+      "@id": "dct:spatial",
+      "@context": {
+        "location": {
+          "@id": "dct:location"
+        },
+        "address": {
+          "@id": "sc:address",
+          "@type": "xsd:string"
+        },
+        "latitude": {
+          "@id": "sc:latitude",
+          "@type": "xsd:decimal"
+        },
+        "longitude": {
+          "@id": "sc:longitude",
+          "@type": "xsd:decimal"
+        },
+        "extent": {
+          "@id": "oeo:BFO_0000006"
+        },
+        "resolutionValue": "dcat:spatialResolutionInMeters",
+        "resolutionUnit": {
+          "@id": "oeo:unit",
+          "@type": "xsd:string"
+        },
+        "boundingBox": {
+          "@id": "dcat:bbox",
+          "@container": "@list",
+          "@type": "xsd:decimal"
+        },
+        "crs": {
+          "@id": "cco:ont00000469",
+          "@type": "xsd:string"
+        }
+      }
+    },
+    "temporal": {
+      "@id": "dct:temporal",
+      "@context": {
+        "referenceDate": {
+          "@id": "dct:date",
+          "@type": "xsd:date"
+        },
+        "timeseries": {
+          "@id": "dct:PeriodOfTime",
+          "@container": "@set"
+        },
+        "resolutionValue": {
+          "@id": "dcat:temporalResolution",
+          "@type": "xsd:decimal"
+        },
+        "resolutionUnit": {
+          "@id": "oeo:unit",
+          "@type": "xsd:string"
+        },
+        "alignment": {
+          "@id": "oeo:OEO_00140044",
+          "@type": "xsd:string"
+        },
+        "aggregationType": {
+          "@id": "oeo:OEO_00140068",
+          "@type": "xsd:string"
+        }
+      }
+    },
+    "sources": {
+      "@id": "dct:source",
+      "@container": "@set"
+    },
+    "authors": {
+      "@id": "oeo:OEO_00000064",
+      "@type": "xsd:string"
+    },
+    "publicationYear": {
+      "@id": "dct:issued",
+      "@type": "xsd:date"
+    },
+    "sourcePath": {
+      "@id": "dcat:accessURL",
+      "@type": "xsd:string"
+    },
+    "sourceLicenses": {
+      "@id": "dct:license",
+      "@container": "@set"
+    },
+    "instruction": {
+      "@id": "rdfs:comment",
+      "@type": "xsd:string"
+    },
+    "attribution": {
+      "@id": "spdx:attributionText",
+      "@type": "xsd:string"
+    },
+    "copyrightStatement": {
+      "@id": "dct:rights",
+      "@type": "xsd:string"
+    },
+    "licenses": {
+      "@id": "dct:license",
+      "@container": "@set"
+    },
+    "contributors": {
+      "@id": "foaf:Agent",
+      "@container": "@set"
+    },
+    "organization": {
+      "@id": "oeo:OEO_00030022",
+      "@type": "xsd:string"
+    },
+    "roles": {
+      "@id": "oeo:BFO_0000023",
+      "@container": "@set",
+      "@type": "xsd:string"
+    },
+    "date": {
+      "@id": "dct:issued",
+      "@type": "xsd:date"
+    },
+    "object": {
+      "@id": "dct:type",
+      "@type": "xsd:string"
+    },
+    "comment": {
+      "@id": "rdfs:comment",
+      "@type": "xsd:string"
+    },
+    "type": {
+      "@id": "csvw:datatype",
+      "@type": "xsd:string"
+    },
+    "format": {
+      "@id": "dct:format",
+      "@type": "xsd:string"
+    },
+    "encoding": {
+      "@id": "csvw:encoding",
+      "@type": "xsd:string"
+    },
+    "schema": "@nest",
+    "nestedFields": {
+      "@id": "csvw:column",
+      "@container": "@set"
+    },
+    "schemaFields": {
+      "@id": "csvw:column"
+    },
+    "nullable": {
+      "@id": "ncit:NCIT_C47840",
+      "@type": "xsd:boolean"
+    },
+    "unit": {
+      "@id": "oeo:OEO_00040010",
+      "@type": "xsd:string"
+    },
+    "isAbout": {
+      "@id": "sc:about",
+      "@container": "@set"
+    },
+    "valueReference": {
+      "@id": "prov:value",
+      "@container": "@set"
+    },
+    "value": {
+      "@id": "rdf:value",
+      "@type": "xsd:string"
+    },
+    "primaryKey": {
+      "@id": "csvw:primaryKey",
+      "@container": "@set",
+      "@type": "xsd:string"
+    },
+    "foreignKeys": {
+      "@id": "csvw:foreignKey",
+      "@container": "@set"
+    },
+    "reference": "@nest",
+    "resource": {
+      "@id": "dcat:Distribution",
+      "@type": "xsd:string"
+    },
+    "fields": {
+      "@id": "csvw:column",
+      "@container": "@set",
+      "@type": "xsd:string"
+    },
+    "dialect": "@nest",
+    "delimiter": {
+      "@id": "csvw:delimiter",
+      "@type": "xsd:string"
+    },
+    "decimalSeparator": {
+      "@id": "csvw:decimalChar",
+      "@type": "xsd:string"
+    },
+    "review": "@nest",
+    "badge": {
+      "@id": "oeo:OEO_00140098",
+      "@type": "xsd:string"
+    },
+    "metaMetadata": "@nest",
+    "metadataVersion": {
+      "@id": "owl:versionInfo",
+      "@type": "xsd:string"
+    },
+    "metadataLicense": "@nest"
+  }
+}

--- a/oemetadata/v2/v21/example.json
+++ b/oemetadata/v2/v21/example.json
@@ -1,0 +1,349 @@
+{
+  "@context": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/latest/context.json",
+  "name": "oep_oemetadata",
+  "title": "OEP OEMetadata",
+  "description": "A dataset for the OEMetadata examples.",
+  "@id": "https://databus.openenergyplatform.org/oeplatform/supply/wri_global_power_plant_database/",
+  "resources": [
+    {
+      "@id": "https://databus.openenergyplatform.org/oeplatform/supply/wri_global_power_plant_database/2022-11-07/wri_global_power_plant_database_variant=data.csv",
+      "name": "oemetadata_table_template",
+      "topics": [
+        "model_draft"
+      ],
+      "title": "OEMetadata Table Template",
+      "path": "http://openenergyplatform.org/dataedit/view/model_draft/oemetadata_table_template",
+      "description": "Example table used to illustrate the OEMetadata structure and features.",
+      "languages": [
+        "en-GB",
+        "de-DE"
+      ],
+      "subject": [
+        {
+          "name": "energy",
+          "@id": "https://openenergyplatform.org/ontology/oeo/OEO_00000150"
+        }
+      ],
+      "keywords": [
+        "example",
+        "ODbL-1.0",
+        "NFDI4Energy"
+      ],
+      "publicationDate": "2024-10-15",
+      "embargoPeriod": {
+        "start": "2024-10-11",
+        "end": "2025-01-01",
+        "isActive": true
+      },
+      "context": {
+        "title": "NFDI4Energy",
+        "homepage": "https://nfdi4energy.uol.de/",
+        "documentation": "https://nfdi4energy.uol.de/sites/about_us/",
+        "sourceCode": "https://github.com/NFDI4Energy",
+        "publisher": "Open Energy Platform (OEP)",
+        "publisherLogo": "https://github.com/OpenEnergyPlatform/organisation/blob/production/logo/OpenEnergyFamily_Logo_OpenEnergyPlatform.svg",
+        "contact": "contact@example.com",
+        "fundingAgency": " Deutsche Forschungsgemeinschaft (DFG)",
+        "fundingAgencyLogo": "https://upload.wikimedia.org/wikipedia/commons/8/86/DFG-logo-blau.svg",
+        "grantNo": "501865131"
+      },
+      "spatial": {
+        "location": {
+          "address": "Rudower Chaussee 12, 12489 Berlin",
+          "@id": "https://www.wikidata.org/wiki/Q77077223",
+          "latitude": "52.432822",
+          "longitude": "13.5351004"
+        },
+        "extent": {
+          "name": "Berlin",
+          "@id": "https://www.wikidata.org/wiki/Q64",
+          "resolutionValue": "100",
+          "resolutionUnit": "m",
+          "boundingBox": [
+            13.08825,
+            52.33859,
+            13.76104,
+            52.6754
+          ],
+          "crs": "EPSG:4326"
+        }
+      },
+      "temporal": {
+        "referenceDate": "2020-01-01",
+        "timeseries": [
+          {
+            "start": "2020-01-01T00:00:00+01:00",
+            "end": "2020-01-01T23:59:30+01:00",
+            "resolutionValue": "15",
+            "resolutionUnit": "min",
+            "alignment": "left",
+            "aggregationType": "current"
+          }
+        ]
+      },
+      "sources": [
+        {
+          "title": "IPCC Sixth Assessment Report (AR6) - Climate Change 2023 - Synthesis Report",
+          "authors": [
+            "Hoesung Lee",
+            "José Romero",
+            "The Core Writing Team"
+          ],
+          "description": "A Report of the Intergovernmental Panel on Climate Change.",
+          "publicationYear": "2023",
+          "path": "https://www.ipcc.ch/report/ar6/syr/downloads/report/IPCC_AR6_SYR_FullVolume.pdf",
+          "sourceLicenses": [
+            {
+              "name": "CC-BY-4.0",
+              "title": "Creative Commons Attribution 4.0 International",
+              "path": "https://creativecommons.org/licenses/by/4.0/legalcode",
+              "instruction": "You are free to share and change, but you must attribute. See https://www.tldrlegal.com/license/creative-commons-attribution-4-0-international-cc-by-4 for further information.",
+              "attribution": "© Intergovernmental Panel on Climate Change 2023",
+              "copyrightStatement": "https://www.ipcc.ch/copyright/"
+            }
+          ]
+        }
+      ],
+      "licenses": [
+        {
+          "name": "ODbL-1.0",
+          "title": "Open Data Commons Open Database License 1.0",
+          "path": "https://opendatacommons.org/licenses/odbl/1-0/index.html",
+          "instruction": "You are free to share and change, but you must attribute, and share derivations under the same license. See https://tldrlegal.com/license/odc-open-database-license-(odbl) for further information.",
+          "attribution": "© Reiner Lemoine Institut",
+          "copyrightStatement": "https://github.com/OpenEnergyPlatform/oemetadata/blob/production/LICENSE.txt"
+        }
+      ],
+      "contributors": [
+        {
+          "title": "Ludwig Hülk",
+          "path": "https://github.com/Ludee",
+          "organization": "Reiner Lemoine Institut",
+          "roles": [
+            "DataCollector"
+          ],
+          "date": "2024-11-19",
+          "object": "data",
+          "comment": "Date of data creation"
+        },
+        {
+          "title": "Ludwig Hülk",
+          "path": "https://github.com/Ludee",
+          "organization": "Reiner Lemoine Institut",
+          "roles": [
+            "DataCurator"
+          ],
+          "date": "2024-11-30",
+          "object": "metadata",
+          "comment": "Date of metadata creation"
+        }
+      ],
+      "type": "table",
+      "format": "CSV",
+      "encoding": "UTF-8",
+      "schema": {
+        "fields": [
+          {
+            "name": "id",
+            "description": "Unique identifier",
+            "type": "serial",
+            "nullable": false,
+            "unit": null,
+            "isAbout": [
+              {
+                "name": "identifier",
+                "@id": "http://purl.obolibrary.org/obo/IAO_0020000"
+              }
+            ],
+            "valueReference": [
+              {
+                "value": null,
+                "name": null,
+                "@id": null
+              }
+            ]
+          },
+          {
+            "name": "name",
+            "description": "Technology Name",
+            "type": "text",
+            "nullable": true,
+            "unit": null,
+            "isAbout": [
+              {
+                "name": "power generation technology",
+                "@id": "http://openenergy-platform.org/ontology/oeo/OEO_00010423"
+              }
+            ],
+            "valueReference": [
+              {
+                "value": "wind",
+                "name": "wind power technology",
+                "@id": "http://openenergyplatform.org/ontology/oeo/OEO_00010424"
+              }
+            ]
+          },
+          {
+            "name": "type",
+            "description": "Type of wind farm",
+            "type": "text",
+            "nullable": true,
+            "unit": null,
+            "isAbout": [
+              {
+                "name": "wind farm",
+                "@id": "https://openenergyplatform.org/ontology/oeo/OEO_00000447/"
+              }
+            ],
+            "valueReference": [
+              {
+                "value": "onshore",
+                "name": "onshore wind farm",
+                "@id": "https://openenergyplatform.org/ontology/oeo/OEO_00000311/"
+              },
+              {
+                "value": "offshore",
+                "name": "offshore wind farm",
+                "@id": "https://openenergyplatform.org/ontology/oeo/OEO_00000308/"
+              }
+            ]
+          },
+          {
+            "name": "year",
+            "description": "Reference year",
+            "type": "integer",
+            "nullable": true,
+            "unit": null,
+            "isAbout": [
+              {
+                "name": "year",
+                "@id": "https://openenergyplatform.org/ontology/oeo/UO_0000036/"
+              }
+            ],
+            "valueReference": [
+              {
+                "value": null,
+                "name": null,
+                "@id": null
+              }
+            ]
+          },
+          {
+            "name": "value",
+            "description": "Bruttoleistung",
+            "type": "decimal",
+            "nullable": true,
+            "unit": "MW",
+            "isAbout": [
+              {
+                "name": "nameplate capacity",
+                "@id": "https://openenergyplatform.org/ontology/oeo/OEO_00230003/"
+              }
+            ],
+            "valueReference": [
+              {
+                "value": null,
+                "name": null,
+                "@id": null
+              }
+            ]
+          },
+          {
+            "name": "is_active",
+            "description": "Betriebsstatus",
+            "type": "boolean",
+            "nullable": false,
+            "unit": null,
+            "isAbout": [
+              {
+                "name": "Operating Mode Status",
+                "@id": "https://ontology.brickschema.org/brick/Operating_Mode_Status"
+              }
+            ],
+            "valueReference": [
+              {
+                "value": null,
+                "name": null,
+                "@id": null
+              }
+            ]
+          },
+          {
+            "name": "version",
+            "description": "Version",
+            "type": "integer",
+            "nullable": true,
+            "unit": null,
+            "isAbout": [
+              {
+                "name": "version number",
+                "@id": "http://purl.obolibrary.org/obo/IAO_0000129"
+              }
+            ],
+            "valueReference": [
+              {
+                "value": null,
+                "name": null,
+                "@id": null
+              }
+            ]
+          },
+          {
+            "name": "comment",
+            "description": "",
+            "type": "text",
+            "nullable": true,
+            "unit": null,
+            "isAbout": [
+              {
+                "name": "comment",
+                "@id": "http://semanticscience.org/resource/SIO_001167"
+              }
+            ],
+            "valueReference": [
+              {
+                "value": null,
+                "name": null,
+                "@id": null
+              }
+            ]
+          }
+        ],
+        "primaryKey": [
+          "id"
+        ],
+        "foreignKeys": [
+          {
+            "fields": [
+              "id",
+              "version"
+            ],
+            "reference": {
+              "resource": "model_draft.oep_oemetadata_table_example_version",
+              "fields": [
+                "id",
+                "version"
+              ]
+            }
+          }
+        ]
+      },
+      "dialect": {
+        "delimiter": ";",
+        "decimalSeparator": "."
+      },
+      "review": {
+        "path": "https://openenergyplatform.org/dataedit/view/model_draft/oep_table_example/open_peer_review/",
+        "badge": "Platinum"
+      }
+    }
+  ],
+  "metaMetadata": {
+    "metadataVersion": "OEMetadata-2.0.4",
+    "metadataLicense": {
+      "name": "CC0-1.0",
+      "title": "Creative Commons Zero v1.0 Universal",
+      "path": "https://creativecommons.org/publicdomain/zero/1.0"
+    }
+  }
+}

--- a/oemetadata/v2/v21/example.py
+++ b/oemetadata/v2/v21/example.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2024 Ludwig Hülk <@Ludee> © Reiner Lemoine Institut
+# SPDX-FileCopyrightText: 2024 Jonas Huber <jh-RLI> © Reiner Lemoine Institut
+# SPDX-FileCopyrightText: oemetadata <https://github.com/OpenEnergyPlatform/oemetadata/>
+# SPDX-License-Identifier: MIT
+
+import json
+import os
+
+
+with open(os.path.join(os.path.dirname(__file__), "example.json"), "rb") as f:
+    OEMETADATA_V20_EXAMPLE = json.loads(f.read())

--- a/oemetadata/v2/v21/metadata_key_description.md
+++ b/oemetadata/v2/v21/metadata_key_description.md
@@ -1,0 +1,1561 @@
+<!--
+SPDX-FileCopyrightText: 2026 Ludwig Hülk <Ludee> © Reiner Lemoine Institut
+SPDX-FileCopyrightText: 2026 Jonas Huber <jh-RLI> © Reiner Lemoine Institut
+
+SPDX-License-Identifier: MIT
+-->
+
+# OEMetadata - Key Description
+
+This pages describes the key of **OEMetadata version 2.1 .** <br>
+You can have a look at an empty [template](https://github.com/OpenEnergyPlatform/oemetadata/blob/production/oemetadata/latest/template.json) and a filled out [example](https://github.com/OpenEnergyPlatform/oemetadata/blob/production/oemetadata/latest/example.json) of the metadata string.<br>
+The [`schema.json`](https://github.com/OpenEnergyPlatform/oemetadata/blob/production/oemetadata/latest/schema.json) contains the complete metadata schema.
+
+## Introduction
+
+### JSON Format
+
+The JSON format offers different formats:
+
+* key-value pair:
+    ```JSON
+    {"key":"value"}
+    ```
+* array:
+    ```JSON
+    {"key":
+        ["value","value"]}
+    ```
+* object {nested key}:
+    ```JSON
+    {"key": {
+        "key_a":"value",
+        "key_b":"value"}}
+    ```
+* array of objects {nested array}:
+    ```JSON
+    {"key": [
+        {"key_a":"value"},
+        {"key_a":"value"}]}
+    ```
+
+### Cardinality
+The cardinality defines the number of times an element can occur.
+
+* [1]  Mandatory
+* [0..1] Optional
+* [*] Multiple optional
+* [1..*] Mandatory and multiple optional
+
+### Badges
+Badges indicate the priority of metadata keys.<br>
+They are implemented as part of the [Open Peer Review Process](https://openenergyplatform.github.io/academy/courses/09_peer_review/).
+
+### Additional information:<br>
+If a field is not applicable use: `null`.<br>
+If a value is not yet available, use: `ToDo`.
+
+## Overview
+
+### Dataset - General Keys
+| <div style="width:1em">#</div> | <div style="width:6em">Key</div> | <div style="width:20em">Description</div>                                                                                                                                        | <div style="width:20em">Example<div>                                                                                                                                                  | <div style="width:20em">Ontology Class</div>               | <div style="width:4em">Badge</div> | <div style="width:3em">Card.</div> |
+|--------------------------------|----------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------|------------------------------------|------------------------------------|
+| 1                              | @context                         | Explanation of metadata keys in ontology terms.                                                                                                                                  | [context.json](https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/latest/context.json)                                                     test    | test                                                       | Platinum                           | [0..1]                             |
+| 2                              | @id                              | A unique identifier (UUID/DOI) for the dataset. This is the Databus Artifact.                                                                                                    | [databus.openenergyplatform.org/oeplatform/supply/wri_global_power_plant_database/](https://databus.openenergyplatform.org/oeplatform/supply/wri_global_power_plant_database/)   test | [dct:identifier](http://purl.org/dc/terms/identifier)      | Platinum                           | [0..1]                             |
+| 3                              | name                             | A filename or database conform dataset name.                                                                                                                                     | oep_oemetadata                                                                                                                                                                        | [rdfs:label](https://www.w3.org/2000/01/rdf-schema#/label) | Iron                               | [1]                                |
+| 4                              | title                            | A human readable dataset name.                                                                                                                                                   | OEP OEMetadata                                                                                                                                                                        | [dct:title](http://purl.org/dc/terms/title)                | Bronze                             | [0..1]                             |
+| 5                              | description                      | A free text description of the dataset.                                                                                                                                          | A collection of tables for the OEMetadata examples.                                                                                                                                   | [dct:description](http://purl.org/dc/terms/description)    | Bronze                             | [0..1]                             |
+| 6                              | languages                        | An array of languages used within the described data structures (e.g. titles, descriptions). The language key can be repeated if more languages are used. Standard: IETF (BCP47) | en-GB, de-DE                                                                                                                                                                          | [dct:language](http://purl.org/dc/terms/language)          | Gold                               | [*]                                |
+| 6                              | version                          | A version string identifying the version of the package.                                                                                                                         | 0.1.0                                                                                                                                                                                 | [dct:hasVersion](http://purl.org/dc/terms/hasVersion)      | Bronze                             | [0..1]                             |
+| 6                              | image                            | An image to use for this data package. For example, when showing the package in a listing.                                                                                       | https://avatars.githubusercontent.com/u/37101913?s=96&v=4                                                                                                                             | [dct:hasVersion](http://purl.org/dc/terms/hasVersion)      | Bronze                             | [0..1]                             |
+| 7                              | **subject**                      | An array of objects that references to the subjects of the resource in ontology terms.                                                                                           |                                                                                                                                                                                       |                                                            |                                    | [*]                                |
+| 7.1                            | name                             | A class label of the ontology term.                                                                                                                                              | energy                                                                                                                                                                                | [rdfs:label](https://www.w3.org/2000/01/rdf-schema#/label) | Platinum                           | [0..1]                             |
+| 7.2                            | @id                              | A unique identifier (URI/IRI) of the ontology class.                                                                                                                             | [openenergyplatform.org/ontology/oeo/OEO_00000150](https://openenergyplatform.org/ontology/oeo/OEO_00000150)                                                                          | [dct:subject](http://purl.org/dc/terms/subject)            | Platinum                           | [0..1]                             |
+| 8                              | keywords                         | An array of freely selectable keywords that help with searching and structuring.                                                                                                 | example, ODbL-1.0, NFDI4Energy                                                                                                                                                        | [dcat:keyword](http://www.w3.org/ns/dcat#keyword)          | Silver                             | [*]                                |
+
+### Dataset - Context Keys
+| <div style="width:1em">#</div> | <div style="width:6em">Key</div> | <div style="width:20em">Description</div>                                                                                                                                     | <div style="width:20em">Example</div>                                                                                                                                | <div style="width:20em">Ontology Class</div>                                    | <div style="width:4em">Badge</div> | <div style="width:3em">Card.</div> |
+|--------------------------------|----------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------|------------------------------------|------------------------------------|
+| 1                              | **context**                      | An object that describes the general setting, environment, or project leading to the creation or maintenance of this dataset. In science this is can be the research project. |                                                                                                                                                                      |                                                                                 |                                    | [0..1]                             |
+| 1.1                            | title                            | A title of the associated project.                                                                                                                                            | NFDI4Energy                                                                                                                                                          | [dct:title](http://purl.org/dc/terms/title)                                     | Gold                               | [0..1]                             |
+| 1.2                            | homepage                         | A URL of the project.                                                                                                                                                         | [nfdi4energy.uol.de](https://nfdi4energy.uol.de/)                                                                                                                    | [foaf:homepage](http://xmlns.com/foaf/0.1/homepage)                             | Gold                               | [0..1]                             |
+| 1.3                            | documentation                    | A URL of the project documentation.                                                                                                                                           | [nfdi4energy.uol.de/sites/about_us](https://nfdi4energy.uol.de/sites/about_us/)                                                                                      | [ncit:Project Description](http://purl.obolibrary.org/obo/NCIT_C165054)         | Gold                               | [0..1]                             |
+| 1.4                            | sourceCode                       | A URL of the source code of the project.                                                                                                                                      | [github.com/NFDI4Energy](https://github.com/NFDI4Energy)                                                                                                             | [oeo:code source](https://openenergyplatform.org/ontology/oeo/OEO_00000091/)    | Gold                               | [0..1]                             |
+| 1.5                            | publisher                        | The publishing agency of the data. This can be the OEP.                                                                                                                       | Open Energy Platform (OEP)                                                                                                                                           | [dct:publisher](http://purl.org/dc/terms/publisher)                             | Gold                               | [0..1]                             |
+| 1.6                            | publisherLogo                    | A URL to the logo of the publishing agency of data.                                                                                                                           | [OpenEnergyFamily_Logo_OpenEnergyPlatform.svg](https://github.com/OpenEnergyPlatform/organisation/blob/production/logo/OpenEnergyFamily_Logo_OpenEnergyPlatform.svg) | [foaf:logo](http://xmlns.com/foaf/0.1/logo)                                     | Gold                               | [0..1]                             |
+| 1.7                            | contact                          | A reference to the creator or maintainer of the data set. It can be an email address or a GitHub handle.                                                                      | info@nfdi4energy.org                                                                                                                                                 | [oeo:contact person](https://openenergyplatform.org/ontology/oeo/OEO_00000107/) | Gold                               | [0..1]                             |
+| 1.8                            | fundingAgency                    | A name of the entity providing the funding. This can be a government agency or a company.                                                                                     | Deutsche Forschungsgemeinschaft (DFG)                                                                                                                                | [sc:FundingAgency](http://schema.org/fundingAgency)                             | Gold                               | [0..1]                             |
+| 1.9                            | fundingAgencyLogo                | A URL to the logo or image of the funding agency.                                                                                                                             | [DFG-logo-blau.svg](https://upload.wikimedia.org/wikipedia/commons/8/86/DFG-logo-blau.svg)                                                                           | [foaf:logo](http://xmlns.com/foaf/0.1/logo)                                     | Gold                               | [0..1]                             |
+| 1.10                           | grantNo                          | An identifying grant number. In case of a publicly funded project, this number is assigned by the funding agency.                                                             | 501865131                                                                                                                                                            | [sc:Grant](http://schema.org/)                                                  | Gold                               | [0..1]                             |
+
+### Dataset - Provenance Keys
+| <div style="width:1em">#</div> | <div style="width:6em">Key</div> | <div style="width:20em">Description</div>                                                                                  | <div style="width:20em">Example</div> | <div style="width:20em">Ontology Class</div>                                  | <div style="width:4em">Badge</div> | <div style="width:3em">Card.</div> |
+|--------------------------------|----------------------------------|----------------------------------------------------------------------------------------------------------------------------|---------------------------------------|-------------------------------------------------------------------------------|------------------------------------|------------------------------------|
+| 1                              | **creators**                     | An array of objects of the people or organizations who created the dataset.                                                |                                       | [foaf:Agent](http://xmlns.com/foaf/0.1/Agent)                                 |                                    | [*]                                |
+| 1.1                            | title                            | A name of the creator. Note that the personal name format should be: family, given                                         | Hülk, Ludwig                          | [dct:title](http://purl.org/dc/terms/title)                                   | Bronze                             | [0..1]                             |
+| 1.2                            | path                             | A qualified link or path pointing to a relevant location online for the contributor. This can be the GitHub page or ORCID. | https://github.com/Ludee              | [sc:url](https://schema.org/url)                                              | Bronze                             | [0..1]                             |
+| 1.3                            | organization                     | A string describing the organization this contributor is affiliated to. This can be relevant for the copyright.            | Reiner Lemoine Institut               | [oeo:organisation](https://openenergyplatform.org/ontology/oeo/OEO_00030022/) | Bronze                             | [0..1]                             |
+| 1.4                            | created                          | The datetime on which this was created.                                                                                    | 1985-04-12T23:20                      | [dct:hasVersion](http://purl.org/dc/terms/hasVersion)                         | Bronze                             | [0..1]                             |
+
+| 1                              | **contributors**                 | An array of objects of the people or organizations who contributed to the data or metadata. Should have "Date of data creation" and "Date of metadata creation"                                                                                                                                                                                                 |                                       | [foaf:Agent](http://xmlns.com/foaf/0.1/Agent)                                 |                                    | [*]                                |
+| 1.1                            | title                            | A name of the contributor. Note that the personal name format should be: family, given                                                                                                                                                                                                                                                                                                                                | Hülk, Ludwig                           | [dct:title](http://purl.org/dc/terms/title)                                   | Bronze                             | [0..1]                             |
+| 1.2                            | path                             | A qualified link or path pointing to a relevant location online for the contributor. This can be the GitHub page or ORCID.                                                                                                                                                                                                                                      | https://github.com/Ludee              | [sc:url](https://schema.org/url)                                              | Bronze                             | [0..1]                             |
+| 1.3                            | organization                     | A string describing the organization this contributor is affiliated to. This can be relevant for the copyright.                                                                                                                                                                                                                                                 | Reiner Lemoine Institut               | [oeo:organisation](https://openenergyplatform.org/ontology/oeo/OEO_00030022/) | Bronze                             | [0..1]                             |
+| 1.4                            | roles                            | An array describing the roles of the contributor. A role is recommended to follow the established vocabulary: [DataCite Metadata Schema’s contributorRole](https://support.datacite.org/docs/datacite-metadata-schema-v44-recommended-and-optional-properties#7a-contributortype). Useful roles to indicate are: DataCollector, ContactPerson, and DataCurator. | DataCollector, DataCurator            | [oeo:role](https://openenergyplatform.org/ontology/oeo/BFO_0000023/)          | Bronze                             | [*]                                |
+| 1.5                            | date                             | The date of the contribution. Date Format is ISO 8601.                                                                                                                                                                                                                                                                                                          | 2024-10-21                            | [dct:issued](http://purl.org/dc/terms/issued)                                 | Bronze                             | [0..1]                             |
+| 1.6                            | object                           | The target of the contribution. This can be the data, the metadata or both (data and metadata).                                                                                                                                                                                                                                                                 | data and metadata                     | [dct:type](http://purl.org/dc/terms/type)                                     | Bronze                             | [0..1]                             |
+| 1.7                            | comment                          | A free-text commentary on what has been done.                                                                                                                                                                                                                                                                                                                   | Add general context.                  | [rdfs:comment](https://www.w3.org/2000/01/rdf-schema#comment)                 | Bronze                             | [0..1]                             |
+
+### Dataset - Licenses Keys
+| <div style="width:1em">#</div> | <div style="width:6em">Key</div> | <div style="width:20em">Description</div>                                                                           | <div style="width:20em">Example</div>                                                                                                                                                                              | <div style="width:20em">Ontology Class</div>                        | <div style="width:4em">Badge</div> | <div style="width:3em">Card.</div> |
+|--------------------------------|----------------------------------|---------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------|------------------------------------|------------------------------------|
+| 1                              | **datasetLicenses**              | An array of objects of licenses under which the described data is provided.                                         |                                                                                                                                                                                                                    | [dct:license](http://purl.org/dc/terms/license)                     |                                    | [*]                                |
+| 1.1                            | name                             | The [SPDX](https://spdx.org/licenses/) identifier.                                                                  | ODbL-1.0                                                                                                                                                                                                           | [rdfs:label](https://www.w3.org/2000/01/rdf-schema#/label)          | Bronze                             | [0..1]                             |
+| 1.2                            | title                            | The official (human-readable) title of the license.                                                                 | Open Data Commons Open Database License 1.0                                                                                                                                                                        | [dct:title](http://purl.org/dc/terms/title)                         | Bronze                             | [0..1]                             |
+| 1.3                            | path                             | A link or path to the license text.                                                                                 | [opendatacommons.org/licenses/odbl/1-0/index.html](https://opendatacommons.org/licenses/odbl/1-0/index.html)                                                                                                       | [dcat:accessURL](https://www.w3.org/ns/dcat#accessURL)              | Bronze                             | [0..1]                             |
+| 1.4                            | instruction                      | A short description of rights and obligations. The use of [tl;drLegal](https://tldrlegal.com/) is recommended.      | You are free to share and change, but you must attribute, and share derivations under the same license. See [tldrlegal.com](https://tldrlegal.com/license/odc-open-database-license-odbl) for further information. | [dc:rights](http://purl.org/dc/elements/1.1/rights)                 | Bronze                             | [0..1]                             |
+| 1.5                            | attribution                      | A copyright owner of the **data**. Must be provided if attribution licenses are used.                               | © Reiner Lemoine Institut                                                                                                                                                                                          | [spdx:attributionText](http://spdx.org/rdf/terms#attributionText)   | Bronze                             | [0..1]                             |
+| 1.6                            | copyrightStatement               | A link or path that proves that the data has the appropriate license. This can be a page number or website imprint. | [www.ipcc.ch/copyright/](https://www.ipcc.ch/copyright/)                                                                                                                                                           | [dct:rights](http://purl.org/dc/terms/rights)                       | Bronze                             | [0..1]                             |
+
+### Dataset - Review Keys
+| <div style="width:1em">#</div> | <div style="width:6em">Key</div> | <div style="width:20em">Description</div>                                                                                                                                                                    | <div style="width:20em">Example</div>                                                                                | <div style="width:20em">Ontology Class</div>                                          | <div style="width:4em">Badge</div> |
+|--------------------------------|----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------|------------------------------------|
+| 1.                             | **review**                       | The metadata on the OEP can go through an open peer review process. See the Academy course [Open Peer Review](https://openenergyplatform.github.io/academy/courses/09_peer_review/) for further information. |                                                                                                                      |                                                                                       | [0..1]                             |
+| 1.1                            | path                             | A link or path to the documented open peer review.                                                                                                                                                           | [open_peer_review/9](https://openenergyplatform.org/dataedit/view/model_draft/oep_table_example/open_peer_review/9/) | [sc:url](https://schema.org/url)                                                      | [0..1]                             |
+| 1.2                            | badge                            | A badge of either Iron, Bronze, Silver, Gold or Platinum is used to label the quality of the metadata.                                                                                                       | Platinum                                                                                                             | [oeo:quality control flag](https://openenergyplatform.org/ontology/oeo/OEO_00140098/) | [0..1]                             |
+
+### Resource
+| <div style="width:1em">#</div> | <div style="width:6em">Key</div> | <div style="width:20em">Description</div>                                                | <div style="width:20em">Example<div> | <div style="width:20em">Ontology Class</div>       | <div style="width:4em">Badge</div> | <div style="width:3em">Card.</div> |
+|--------------------------------|----------------------------------|------------------------------------------------------------------------------------------|--------------------------------------|----------------------------------------------------|------------------------------------|------------------------------------|
+| 1                              | **resources**                    | An array of objects of the resources. The dataset can contain several (database) tables. |                                      | [dcat:Dataset](https://www.w3.org/ns/dcat#dataset) |                                    | [*]                                |
+
+### Resource - General Keys
+| <div style="width:1em">#</div> | <div style="width:6em">Key</div> | <div style="width:20em">Description</div>                                                                                                                                        | <div style="width:20em">Example</div>                                                                                                  | <div style="width:20em">Ontology Class</div>                    | <div style="width:4em">Badge</div> | <div style="width:3em">Card.</div> |
+|--------------------------------|----------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------|------------------------------------|------------------------------------|
+| 1                              | @id                              | A Uniform Resource Identifier (URI) that links the resource via the OpenEnergyDatabus (DBpedia Databus).                                                                         | [wri_global_power_plant_database](https://databus.openenergyplatform.org/oeplatform/supply/wri_global_power_plant_database/2022-11-07) | [dct:identifier](http://purl.org/dc/terms/identifier)           | Platinum                           | [0..1]                             |
+| 2                              | path                             | A unique identifier (URI/UUID/DOI) for the table or file.                                                                                                                        | [oemetadata_table_template](https://openenergyplatform.org/database/tables/oemetadata_table_template)             | [dcat:accessURL](https://www.w3.org/ns/dcat#accessURL)          | Bronze                             | [0..1]                             |
+| 3                              | name                             | A filename or database conform table name.                                                                                                                                       | oemetadata_table_template                                                                                                              | [rdfs:label](https://www.w3.org/2000/01/rdf-schema#/label)      | Iron                               | [1]                                |
+| 4                              | title                            | A human readable resource or table name.                                                                                                                                         | OEMetadata Table                                                                                                                       | [dct:title](http://purl.org/dc/terms/title)                     | Silver                             | [0..1]                             |
+| 5                              | description                      | A description of the table. It should be usable as summary information for the table that is described by the metadata.                                                          | Example table used to illustrate the OEMetadata structure and features.                                                                | [dct:description](http://purl.org/dc/terms/description)         | Silver                             | [0..1]                             |
+| 7                              | **subject**                      | An array of objects that references to the subjects of the resource in ontology terms.                                                                                           |                                                                                                                                        |                                                                 |                                    | [*]                                |
+| 7.1                            | name                             | A class label of the ontology term.                                                                                                                                              | energy                                                                                                                                 | [rdfs:label](https://www.w3.org/2000/01/rdf-schema#/label)      | Platinum                           | [0..1]                             |
+| 7.2                            | @id                              | A unique identifier (URI/IRI) of the ontology class.                                                                                                                             | [openenergyplatform.org/ontology/oeo/OEO_00000150](https://openenergyplatform.org/ontology/oeo/OEO_00000150)                           | [dct:subject](http://purl.org/dc/terms/subject)                 | Platinum                           | [0..1]                             |
+| 8                              | keywords                         | An array of freely selectable keywords that help with searching and structuring. The keyword are used and managed in the OEP as table tags.                                      | example, ODbL-1.0, NFDI4Energy                                                                                                         | [dcat:keyword](http://www.w3.org/ns/dcat#keyword)               | Silver                             | [*]                                |
+| 9                              | publicationDate                  | A date of publication of the data or metadata. The date format is ISO 8601 (YYYY-MM-DD).                                                                                         | 2024-10-15                                                                                                                             | [dct:issued](http://purl.org/dc/terms/issued)                   | Bronze                             | [0..1]                             |
+| 10                             | **embargoPeriod**                | An object that describes the embargo period during which public access to the data is not allowed.                                                                               |                                                                                                                                        |                                                                 |                                    | [0..1]                             |
+| 10.1                           | start                            | The start date of the embargo period. The date of the data (metadata) upload.                                                                                                    | 2024-10-11                                                                                                                             | [dbo:startDateTime](https://dbpedia.org/ontology/startDateTime) | Bronze                             | [0..1]                             |
+| 10.2                           | end                              | The end date of the embargo period. This is the envisioned publication date.                                                                                                     | 2025-01-01                                                                                                                             | [dbo:endDateTime](https://dbpedia.org/ontology/endDateTime)     | Bronze                             | [0..1]                             |
+| 10.3                           | isActive                         | A boolean key that indicates if the embargo period is currently active. Must be changed to False on the embargo period end date.                                                 | True                                                                                                                                   | [adms:status](http://www.w3.org/ns/adms#status)                 | Bronze                             | [0..1]                             |
+
+
+### Resource - Spatial Keys
+| <div style="width:1em">#</div> | <div style="width:6em">Key</div> | <div style="width:20em">Description</div>                                                                                     | <div style="width:20em">Example</div>                                      | <div style="width:20em">Ontology Class</div>                                                                                             | <div style="width:4em">Badge</div> | <div style="width:3em">Card.</div> |
+|--------------------------------|----------------------------------|-------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|------------------------------------|
+| 1                              | **spatial**                      | An object that describes the spatial context of the data.                                                                     |                                                                            |                                                                                                                                          |                                    | [0..1]                             |
+| 1.1                            | **location**                     | An object that describes a specific location.                                                                                 |                                                                            | [dct:location](http://purl.org/dc/terms/Location)                                                                                        |                                    | [0..1]                             |
+| 1.1.1                          | address                          | An address of the location of the data. May be specified with street name, house number, zip code, and city name.             | Rudower Chaussee 12, 12489 Berlin                                          | [schema:address](https://schema.org/address)                                                                                             | Silver                             | [0..1]                             |
+| 1.1.2                          | @id                              | A path or URI to a specific location. It can use Wikidata or OpenStreetMap.                                                   | [www.wikidata.org/wiki/Q77077223](https://www.wikidata.org/wiki/Q77077223) | [dct:identifier](http://purl.org/dc/terms/identifier)                                                                                    | Platinum                           | [0..1]                             |
+| 1.1.3                          | latitude                         | The latitude (lat) information of the location.                                                                               | 52.432822                                                                  | [schema:latitude](https://schema.org/latitude)                                                                                           | Gold                               | [0..1]                             |
+| 1.1.4                          | longitude                        | The longitude (lon) information of the location.                                                                              | 13.5351004                                                                 | [schema:longitude](https://schema.org/longitude)                                                                                         | Gold                               | [0..1]                             |
+| 1.2                            | **extent**                       | An object that describes a covered area or region.                                                                            |                                                                            | [oeo:spatial region](http://purl.obolibrary.org/obo/BFO_0000006)                                                                         |                                    | [0..1]                             |
+| 1.2.1                          | name                             | The name of the region.                                                                                                       | Berlin                                                                     | [rdfs:label](https://www.w3.org/2000/01/rdf-schema#/label)                                                                               | Silver                             | [0..1]                             |
+| 1.2.2                          | @id                              | A URI reference for the region.                                                                                               | [www.wikidata.org/wiki/Q64](https://www.wikidata.org/wiki/Q64)             | [dct:identifier](http://purl.org/dc/terms/identifier)                                                                                    | Platinum                           | [0..1]                             |
+| 1.2.3                          | resolutionValue                  | The value of the spatial resolution.                                                                                          | 100                                                                        | [dcat:spatialResolutionInMeters](http://www.w3.org/ns/dcat#spatialResolutionInMeters)                                                    | Silver                             | [0..1]                             |
+| 1.2.4                          | resolutionUnit                   | The unit of the spatial resolution.                                                                                           | m                                                                          | [oeo:unit](http://openenergyplatform.org/ontology/oeo/OEO_00010489)                                                                      | Silver                             | [0..1]                             |
+| 1.2.5                          | boundingBox                      | The covered area specified by the coordinates of a bounding box. The format is [minLon, minLat, maxLon, maxLat] or [W,S,E,N]. | [13.08825, 52.33859, 13.76104, 52.6754]                                    | [dcat:bbox](http://www.w3.org/ns/dcat#bbox)                                                                                              | Gold                               | [*]                                |
+| 1.2.6                          | crs                              | The Coordinate Reference System, specified as an EPSG code.                                                                   | EPSG:4326                                                                  | [cco:Geospatial Coordinate Reference System](http://www.ontologyrepository.com/CommonCoreOntologies/GeospatialCoordinateReferenceSystem) | Gold                               | [0..1]                             |
+
+### Resource - Temporal Keys
+| <div style="width:1em">#</div> | <div style="width:6em">Key</div> | <div style="width:20em">Description</div>                                                                                                                   | <div style="width:20em">Example</div> | <div style="width:20em">Ontology Class</div>                                          | <div style="width:4em">Badge</div> | <div style="width:3em">Card.</div> |
+|--------------------------------|----------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------|---------------------------------------------------------------------------------------|------------------------------------|------------------------------------|
+| 1                              | **temporal**                     | An object with the time period covered in the data. Temporal information should contain a "referenceDate" or the keys that describe a time series, or both. |                                       | [schema:temporalCoverage](https://schema.org/temporalCoverage)                        |                                    | [0..1]                             |
+| 1.1                            | referenceDate                    | A base year, month or day. The time for which the data should be accurate. Date Format is ISO 8601.                                                         | 2020-01-01                            | [dct:date](http://purl.org/dc/terms/date)                                             | Silver                             | [0..1]                             |
+| 1.2                            | **timeseries**                   | An array that describes the timeseries.                                                                                                                     |                                       | [dct:PeriodOfTime](http://purl.org/dc/terms/PeriodOfTime)                             |                                    | [*]                                |
+| 1.2.1                          | start                            | The start time of a time series.                                                                                                                            | 2020-01-01T00:00:00+00:00             | [dbo:startDateTime](https://dbpedia.org/ontology/startDateTime)                       | Silver                             | [0..1]                             |
+| 1.2.2                          | end                              | The temporal end point of a time series.                                                                                                                    | 2020-01-01T23:59:30+00:00             | [dbo:endDateTime](https://dbpedia.org/ontology/endDateTime)                           | Silver                             | [0..1]                             |
+| 1.2.3                          | resolutionValue                  | The time span between individual information points in a time series. The value of the resolution.                                                          | 15                                    | [dcat:spatialResolutionInMeters](http://www.w3.org/ns/dcat#spatialResolutionInMeters) | Silver                             | [0..1]                             |
+| 1.2.4                          | resolutionUnit                   | The unit of the temporal resolution.                                                                                                                        | min                                   | [oeo:unit](http://openenergyplatform.org/ontology/oeo/OEO_00010489)                   | Silver                             | [0..1]                             |
+| 1.2.5                          | alignment                        | An indicator of whether timestamps in a time series are to the left, right or in the centre.                                                                | left                                  | [oeo:time stamp alignment](http://openenergyplatform.org/ontology/oeo/OEO_00140044)   | Silver                             | [0..1]                             |
+| 1.2.6                          | aggregationType                  | An indicator of whether the values are a sum, an average or a current value.                                                                                | current                               | [oeo:aggregation type](https://openenergyplatform.org/ontology/oeo/OEO_00140068/)     | Silver                             | [0..1]                             |
+
+### Resource - Sources Keys
+| <div style="width:1em">#</div> | <div style="width:6em">Key</div> | <div style="width:20em">Description</div>                                                                                                                                                                     | <div style="width:20em">Example</div>                                                                                                                                                                              | <div style="width:20em">Ontology Class</div>                            | <div style="width:4em">Badge</div> | <div style="width:3em">Card.</div> |
+|--------------------------------|----------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------|------------------------------------|------------------------------------|
+| 1                              | **sources**                      | An array of objects with the used and underlying sources of the data and metadata.                                                                                                                            |                                                                                                                                                                                                                    | [dct:source](http://purl.org/dc/terms/source)                           |                                    | [*]                                |
+| 1.1                            | title                            | A human readable title of the source, a document title or organisation name.                                                                                                                                  | IPCC Sixth Assessment Report (AR6) - Climate Change 2023 - Synthesis Report                                                                                                                                        | [dct:title](http://purl.org/dc/terms/title)                             | Bronze                             | [0..1]                             |
+| 1.2                            | authors                          | An array of the full names of the authors of the source material.                                                                                                                                             | Hoesung Lee,José Romero, The Core Writing Team                                                                                                                                                                     | [oeo:author](https://openenergyplatform.org/ontology/oeo/OEO_00000064/) | Bronze                             | [*]                                |
+| 1.3                            | description                      | A free text description of the source.                                                                                                                                                                        | A Report of the Intergovernmental Panel on Climate Change                                                                                                                                                          | [dct:description](http://purl.org/dc/terms/description)                 | Bronze                             | [0..1]                             |
+| 1.4                            | publicationYear                  | Indicates the year when the work was published.                                                                                                                                                               | 2023                                                                                                                                                                                                               | [dct:issued](http://purl.org/dc/terms/issued)                           | Bronze                             | [0..1]                             |
+| 1.5                            | path                             | A DOI or link to the original source.                                                                                                                                                                         | [IPCC_AR6_SYR_FullVolume.pdf](https://www.ipcc.ch/report/ar6/syr/downloads/report/IPCC_AR6_SYR_FullVolume.pdf)                                                                                                     | [sc:url](https://schema.org/url)                                        | Bronze                             | [0..1]                             |
+| 1.6                            | **sourceLicenses**               | An array of objects of licenses under which the described source is provided. See [academy/courses/08_licensing](https://openenergyplatform.github.io/academy/courses/08_licensing/) for further information. |                                                                                                                                                                                                                    | [dct:license](http://purl.org/dc/terms/license)                         |                                    | [*]                                |
+| 1.6.1                          | name                             | The [SPDX](https://spdx.org/licenses/) identifier.                                                                                                                                                            | ODbL-1.0                                                                                                                                                                                                           | [rdfs:label](https://www.w3.org/2000/01/rdf-schema#/label)              | Bronze                             | [0..1]                             |
+| 1.6.2                          | title                            | The official (human-readable) title of the license.                                                                                                                                                           | Open Data Commons Open Database License 1.0                                                                                                                                                                        | [dct:title](http://purl.org/dc/terms/title)                             | Bronze                             | [0..1]                             |
+| 1.6.3                          | path                             | A link or path to the license text.                                                                                                                                                                           | [opendatacommons.org/licenses/odbl/1-0/index.html](https://opendatacommons.org/licenses/odbl/1-0/index.html)                                                                                                       | [sc:url](https://schema.org/url)                                        | Bronze                             | [0..1]                             |
+| 1.6.4                          | instruction                      | A short description of rights and obligations. The use of [tl;drLegal](https://tldrlegal.com/) is recommended.                                                                                                | You are free to share and change, but you must attribute, and share derivations under the same license. See [tldrlegal.com](https://tldrlegal.com/license/odc-open-database-license-odbl) for further information. | [rdfs:comment](https://www.w3.org/2000/01/rdf-schema#comment)           | Bronze                             | [0..1]                             |
+| 1.6.5                          | attribution                      | A copyright owner of the **source**. Must be provided if attribution licenses are used.                                                                                                                       | © Intergovernmental Panel on Climate Change 2023                                                                                                                                                                   | [ms:copyright notice](http://purl.obolibrary.org/obo/MS_1003198)        | Bronze                             | [0..1]                             |
+| 1.6.6                          | copyrightStatement               | A link or path that proves that the source or data has the appropriate license. This can be a page number or website imprint.                                                                                 | [www.ipcc.ch/copyright](https://www.ipcc.ch/copyright/)                                                                                                                                                            | [dct:rights](http://purl.org/dc/terms/rights)                           | Bronze                             | [0..1]                             |
+
+### Resource - Licenses Keys
+| <div style="width:1em">#</div> | <div style="width:6em">Key</div> | <div style="width:20em">Description</div>                                                                           | <div style="width:20em">Example</div>                                                                                                                                                                              | <div style="width:20em">Ontology Class</div>                      | <div style="width:4em">Badge</div> | <div style="width:3em">Card.</div> |
+|--------------------------------|----------------------------------|---------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|------------------------------------|------------------------------------|
+| 1                              | **resourceLicenses**             | An array of objects of licenses under which the described data is provided.                                         |                                                                                                                                                                                                                    | [dct:license](http://purl.org/dc/terms/license)                   |                                    | [*]                                |
+| 1.1                            | name                             | The [SPDX](https://spdx.org/licenses/) identifier.                                                                  | ODbL-1.0                                                                                                                                                                                                           | [rdfs:label](https://www.w3.org/2000/01/rdf-schema#/label)        | Bronze                             | [0..1]                             |
+| 1.2                            | title                            | The official (human-readable) title of the license.                                                                 | Open Data Commons Open Database License 1.0                                                                                                                                                                        | [dct:title](http://purl.org/dc/terms/title)                       | Bronze                             | [0..1]                             |
+| 1.3                            | path                             | A link or path to the license text.                                                                                 | [opendatacommons.org/licenses/odbl/1-0/index.html](https://opendatacommons.org/licenses/odbl/1-0/index.html)                                                                                                       | [dcat:accessURL](https://www.w3.org/ns/dcat#accessURL)            | Bronze                             | [0..1]                             |
+| 1.4                            | instruction                      | A short description of rights and obligations. The use of [tl;drLegal](https://tldrlegal.com/) is recommended.      | You are free to share and change, but you must attribute, and share derivations under the same license. See [tldrlegal.com](https://tldrlegal.com/license/odc-open-database-license-odbl) for further information. | [dc:rights](http://purl.org/dc/elements/1.1/rights)               | Bronze                             | [0..1]                             |
+| 1.5                            | attribution                      | A copyright owner of the **data**. Must be provided if attribution licenses are used.                               | © Reiner Lemoine Institut                                                                                                                                                                                          | [spdx:attributionText](http://spdx.org/rdf/terms#attributionText) | Bronze                             | [0..1]                             |
+| 1.6                            | copyrightStatement               | A link or path that proves that the data has the appropriate license. This can be a page number or website imprint. | [www.ipcc.ch/copyright/](https://www.ipcc.ch/copyright/)                                                                                                                                                           | [dct:rights](http://purl.org/dc/terms/rights)                     | Bronze                             | [0..1]                             |
+
+### Resource - Type Keys
+| <div style="width:1em">#</div> | <div style="width:6em">Key</div> | <div style="width:20em">Description</div>                                                                                                     | <div style="width:20em">Example</div> | <div style="width:20em">Ontology Class</div>         | <div style="width:4em">Badge</div> | <div style="width:3em">Card.</div> |
+|--------------------------------|----------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------|------------------------------------------------------|------------------------------------|------------------------------------|
+| 1                              | type                             | The 'table' type indicates that the resource is tabular as per 'Frictionless Tabular Data' definition.                                        | table                                 | [csvw:datatype](https://www.w3.org/ns/csvw#datatype) | Gold                               | [0..1]                             |
+| 2                              | format                           | A file extension format. Possible options are 'csv', 'xlsx', 'json', 'PostgreSQL', 'SQLite' and other standard file extensions.               | PostgreSQL                            | [dct:format](http://purl.org/dc/terms/format)        | Gold                               | [0..1]                             |
+| 3                              | encoding                         | Specifies the character encoding of the resource's data file. The default is 'UTF-8'. The values should be one of the 'Preferred MIME Names'. | UTF-8                                 | [csvw:encoding](http://www.w3.org/ns/csvw#encoding)  | Gold                               | [0..1]                             |
+
+#### Resource - Fields Keys
+| <div style="width:1em">#</div> | <div style="width:6em">Key</div> | <div style="width:20em">Description</div>                                                                                                                                            | <div style="width:20em">Example</div>                                    | <div style="width:20em">Ontology Class</div>                              | <div style="width:4em">Badge</div> | <div style="width:3em">Card.</div> |
+|--------------------------------|----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------|---------------------------------------------------------------------------|------------------------------------|------------------------------------|
+| 1                              | **schema**                       | An object that describes the structure of a table. It contains all fields (columns of the table), the primary key and optional foreign keys.                                         |                                                                          | [schema:table](https://schema.org/Table)                                  |                                    | [1]                                |
+| 1.1                            | **fields**                       | An array of objects that describes a field (column) and its detailed information.                                                                                                    |                                                                          | [csvw:column](http://www.w3.org/ns/csvw#column)                           |                                    | [1]                                |
+| 1.1.1                          | name                             | The name of the field. The name may only consist of lowercase alphanumeric characters or underscores. It must not begin with a number or an underscore.                              | year                                                                     | [rdfs:label](https://www.w3.org/2000/01/rdf-schema#/label)                | Iron                               | [1]                                |
+| 1.1.2                          | description                      | A text describing the field.                                                                                                                                                         | Reference year for which the data were collected.                        | [dct:description](http://purl.org/dc/terms/description)                   | Silver                             | [0..1]                             |
+| 1.1.3                          | type                             | The data type of the field. In case of a geom column in a database, also indicate the shape and CRS.                                                                                 | geometry(Point, 4326)                                                    | [csvw:datatype](https://www.w3.org/ns/csvw#datatype)                      | Iron                               | [1]                                |
+| 1.1.4                          | nullable                         | A boolean key to specify that a column can be nullable. True is the default value.                                                                                                   | True                                                                     | [ncit:null](http://purl.obolibrary.org/obo/NCIT_C47840)                   | Iron                               | [1]                                |
+| 1.1.5                          | unit                             | The unit of a field. If it does not apply, use 'null'. If the unit is given in a separate field, reference this field (e.g. 'unit').  Use a space between numbers and units (100 m). | MW                                                                       | [oeo:has unit](https://openenergyplatform.org/ontology/oeo/OEO_00040010/) | Silver                             | [0..1]                             |
+| 1.1.6                          | **isAbout**                      | An array of objects that describes the field in ontology terms.                                                                                                                      |                                                                          | [sc:about](https://schema.org/about)                                      |                                    | [*]                                |
+| 1.1.6.1                        | name                             | The class label of the ontology term.                                                                                                                                                | wind energy converting unit                                              | [rdfs:label](https://www.w3.org/2000/01/rdf-schema#/label)                | Platinum                           | [0..1]                             |
+| 1.1.6.2                        | @id                              | The path of the ontology term (IRI).                                                                                                                                                 | [OEO_00000044](https://openenergyplatform.org/ontology/oeo/OEO_00000044) | [dct:identifier](http://purl.org/dc/terms/identifier)                     | Platinum                           | [0..1]                             |
+| 1.1.7                          | **valueReference**               | An array of objects for an extended description of the values in the column in ontology terms.                                                                                       |                                                                          | [prov:value](https://www.w3.org/ns/prov#value)                            |                                    | [*]                                |
+| 1.1.7.1                        | value                            | The name of the value in the column.                                                                                                                                                 | onshore                                                                  | [rdf:value](https://www.w3.org/1999/02/22-rdf-syntax-ns#value)            | Platinum                           | [0..1]                             |
+| 1.1.7.2                        | name                             | The class label of the ontology term in the column.                                                                                                                                  | onshore wind farm                                                        | [rdfs:label](https://www.w3.org/2000/01/rdf-schema#/label)                | Platinum                           | [0..1]                             |
+| 1.1.7.3                        | @id                              | The path of the ontology term (IRI) in the column.                                                                                                                                   | [OEO_00000311](https://openenergyplatform.org/ontology/oeo/OEO_00000311) | [dct:identifier](http://purl.org/dc/terms/identifier)                     | Platinum                           | [0..1]                             |
+
+#### Resource - Properties Keys
+| <div style="width:1em">#</div> | <div style="width:6em">Key</div> | <div style="width:20em">Description</div>                                                                                                                                  | <div style="width:20em">Example</div> | <div style="width:20em">Ontology Class</div>              | <div style="width:4em">Badge</div> | <div style="width:3em">Card.</div> |
+|--------------------------------|----------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------|-----------------------------------------------------------|------------------------------------|------------------------------------|
+| 1.2                            | primaryKey                       | An array of fields that uniquely identifies each row in the table. The default value is the “id” column.                                                                   | id                                    | [csvw:primaryKey](https://www.w3.org/ns/csvw#primaryKey)  | Iron                               | [1..*]                             |
+| 1.3                            | **foreignKeys**                  | An array of objects with foreign keys that describe a field that relates to a field in another table.                                                                      |                                       | [csvw:foreignKey](https://www.w3.org/ns/csvw#foreignKey)  |                                    | [*]                                |
+| 1.3.1                          | fields                           | An array of fields in the table that is constrained by the foreign key.                                                                                                    | id, version                           | [ex:nestedFields](http://example.org/nestedFields)        | Iron                               | [*]                                |
+| 1.3.2                          | **reference**                    | The reference to the foreign table.                                                                                                                                        |                                       |                                                           |                                    | [0..1]                             |
+| 1.3.2.1                        | resource                         | The referenced foreign table.                                                                                                                                              | oemetadata_table_template             | [dcat:Dataset](https://www.w3.org/ns/dcat#dataset)        | Iron                               | [0..1]                             |
+| 1.3.2.2                        | fields                           | The foreign resource column.                                                                                                                                               | id, version                           | [csvw:column](http://www.w3.org/ns/csvw#column)           | Iron                               | [*]                                |
+| 1.4                            | **dialect**                      | The Dialect defines a simple format for describing the various dialects of CSV files in a language-independent manner. In a database, the values in the fields are 'null'. |                                       |                                                           |                                    | [1]                                |
+| 1.4.1                          | delimiter                        | The delimiter specifies the character sequence which should separate fields (columns). Common characters are ',' (comma), ';' (semicolon), '.' (point) and '\t' (tab).     | ,                                     | [csvw:delimiter](http://www.w3.org/ns/csvw#delimiter)     | Iron                               | [1]                                |
+| 1.4.2                          | decimalSeparator                 | The symbol used to separate the integer part from the fractional part of a number written in decimal form. Depending on language and region this symbol can be '.' or ','. | .                                     | [csvw:decimalChar](http://www.w3.org/ns/csvw#decimalChar) | Iron                               | [1]                                |
+
+### MetaMetadata Keys
+| <div style="width:1em">#</div> | <div style="width:6em">Key</div> | <div style="width:20em">Description</div>                                            | <div style="width:20em">Example</div>                                                            | <div style="width:20em">Ontology Class</div>                 | <div style="width:3em">Card.</div> |
+|--------------------------------|----------------------------------|--------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------|--------------------------------------------------------------|------------------------------------|
+| 1                              | **metaMetadata**                 | An object that describes the metadata themselves, their format, version and license. |                                                                                                  |                                                              | [1]                                |
+| 1.1                            | metadataVersion                  | Type and version number of the metadata.                                             | OEMetadata-2.0                                                                                   | [owl:versionInfo](http://www.w3.org/2002/07/owl#versionInfo) | [1]                                |
+| 1.2                            | **metadataLicense**              | The license of the provided metadata.                                                |                                                                                                  | [dct:license](http://purl.org/dc/terms/license)              | [1]                                |
+| 1.2.1                          | name                             | The [SPDX](https://spdx.org/licenses/) identifier.                                   | CC0-1.0                                                                                          | [rdfs:label](https://www.w3.org/2000/01/rdf-schema#/label)   | [1]                                |
+| 1.2.2                          | title                            | The official (human-readable) title of the license.                                  | Creative Commons Zero v1.0 Universal                                                             | [dct:title](http://purl.org/dc/terms/title)                  | [1]                                |
+| 1.2.3                          | path                             | A link or path to the license text.                                                  | [creativecommons.org/publicdomain/zero/1.0/](https://creativecommons.org/publicdomain/zero/1.0/) | [sc:url](https://schema.org/url)                             | [1]                                |
+
+
+## Metadata Keys
+
+### Dataset - @context
+|                    |                                                                                                                           |
+|--------------------|---------------------------------------------------------------------------------------------------------------------------|
+| **Key**            | @context                                                                                                                  |
+| **Description**    | Explanation of metadata keys in ontology terms.                                                                           |
+| **Example**        | [context.json](https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/latest/context.json) |
+| **Ontology Class** |                                                                                                                           |
+| **Badge**          | Platinum                                                                                                                  |
+| **Card.**          | [0..1]                                                                                                                    |
+
+
+### Dataset - name
+|                    |                                                            |
+|--------------------|------------------------------------------------------------|
+| **Key**            | name                                                       |
+| **Description**    | A filename or database conform dataset name.               |
+| **Example**        | oep_oemetadata                                             |
+| **Ontology Class** | [rdfs:label](https://www.w3.org/2000/01/rdf-schema#/label) |
+| **Badge**          | Iron                                                       |
+| **Card.**          | [1]                                                        |
+
+
+### Dataset - title
+|                    |                                             |
+|--------------------|---------------------------------------------|
+| **Key**            | title                                       |
+| **Description**    | A human readable dataset name.              |
+| **Example**        | OEP OEMetadata                              |
+| **Ontology Class** | [dct:title](http://purl.org/dc/terms/title) |
+| **Badge**          | Bronze                                      |
+| **Card.**          | [0..1]                                      |
+
+
+### Dataset - description
+|                    |                                                         |
+|--------------------|---------------------------------------------------------|
+| **Key**            | description                                             |
+| **Description**    | A free text description of the dataset.                 |
+| **Example**        | A collection of tables for the OEMetadata examples.     |
+| **Ontology Class** | [dct:description](http://purl.org/dc/terms/description) |
+| **Badge**          | Bronze                                                  |
+| **Card.**          | [0..1]                                                  |
+
+
+### Dataset - @id
+|                    |                                                                                                                                                                                |
+|--------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Key**            | @id                                                                                                                                                                            |
+| **Description**    | A unique identifier (UUID/DOI) for the dataset. This is the Databus Artifact.                                                                                                  |
+| **Example**        | [databus.openenergyplatform.org/oeplatform/supply/wri_global_power_plant_database/](https://databus.openenergyplatform.org/oeplatform/supply/wri_global_power_plant_database/) |
+| **Ontology Class** | [dct:identifier](http://purl.org/dc/terms/identifier)                                                                                                                          |
+| **Badge**          | Platinum                                                                                                                                                                       |
+| **Card.**          | [0..1]                                                                                                                                                                         |
+
+
+### Dataset - resources
+|                    |                                                                                          |
+|--------------------|------------------------------------------------------------------------------------------|
+| **Key**            | resources                                                                                |
+| **Description**    | An array of objects of the resources. The dataset can contain several (database) tables. |
+| **Example**        |                                                                                          |
+| **Ontology Class** | [dcat:Dataset](https://www.w3.org/ns/dcat#dataset)                                       |
+| **Badge**          |                                                                                          |
+| **Card.**          | [*]                                                                                      |
+
+### Resource - @id
+|                |                                                                                                                                                                                         |
+|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Key            | @id                                                                                                                                                                                     |
+| Description    | A Uniform Resource Identifier (URI) that links the resource via the OpenEnergyDatabus (DBpedia Databus).                                                                                |
+| Example        | [wri_global_power_plant_database](https://databus.openenergyplatform.org/oeplatform/supply/wri_global_power_plant_database/2022-11-07/wri_global_power_plant_database_variant=data.csv) |
+| Ontology Class | [dct:identifier](http://purl.org/dc/terms/identifier)                                                                                                                                   |
+| Badge          | Platinum                                                                                                                                                                                |
+| Card.          | [0..1]                                                                                                                                                                                  |
+
+
+### Resource - name
+|                |                                                            |
+|----------------|------------------------------------------------------------|
+| Key            | name                                                       |
+| Description    | A filename or database conform table name.                 |
+| Example        | oemetadata_table_template                                  |
+| Ontology Class | [rdfs:label](https://www.w3.org/2000/01/rdf-schema#/label) |
+| Badge          | Iron                                                       |
+| Card.          | [1]                                                        |
+
+
+### Resource - topics
+|                |                                                                                   |
+|----------------|-----------------------------------------------------------------------------------|
+| Key            | topics                                                                            |
+| Description    | An array of predefined topics that correspond to the database schemas of the OEP. |
+| Example        | model_draft                                                                       |
+| Ontology Class | [foaf:topic](http://xmlns.com/foaf/spec/#term_topic)                              |
+| Badge          | Bronze                                                                            |
+| Card.          | [*]                                                                               |
+
+
+### Resource - title
+|                |                                             |
+|----------------|---------------------------------------------|
+| Key            | title                                       |
+| Description    | A human readable resource or table name.    |
+| Example        | OEMetadata Table                            |
+| Ontology Class | [dct:title](http://purl.org/dc/terms/title) |
+| Badge          | Silver                                      |
+| Card.          | [0..1]                                      |
+
+
+### Resource - path
+|                |                                                                                                                            |
+|----------------|----------------------------------------------------------------------------------------------------------------------------|
+| Key            | path                                                                                                                       |
+| Description    | A unique identifier (URI/UUID/DOI) for the table or file.                                                                  |
+| Example        | [model_draft/oemetadata_table_template](http://openenergyplatform.org/dataedit/view/model_draft/oemetadata_table_template) |
+| Ontology Class | [dcat:accessURL](https://www.w3.org/ns/dcat#accessURL)                                                                     |
+| Badge          | Bronze                                                                                                                     |
+| Card.          | [0..1]                                                                                                                     |
+
+
+### Resource - description
+|                |                                                                                                                         |
+|----------------|-------------------------------------------------------------------------------------------------------------------------|
+| Key            | description                                                                                                             |
+| Description    | A description of the table. It should be usable as summary information for the table that is described by the metadata. |
+| Example        | Example table used to illustrate the OEMetadata structure and features.                                                 |
+| Ontology Class | [dct:description](http://purl.org/dc/terms/description)                                                                 |
+| Badge          | Silver                                                                                                                  |
+| Card.          | [0..1]                                                                                                                  |
+
+
+### Resource - languages
+|                |                                                                                                                                                                                   |
+|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Key            | languages                                                                                                                                                                         |
+| Description    | An array of languages used within the described data structures (e.g. titles, descriptions). The language key can be repeated if more languages are used. Standard: IETF (BCP47). |
+| Example        | en-GB, de-DE                                                                                                                                                                      |
+| Ontology Class | [dct:language](http://purl.org/dc/terms/language)                                                                                                                                 |
+| Badge          | Gold                                                                                                                                                                              |
+| Card.          | [*]                                                                                                                                                                               |
+
+
+### Resource - subject
+|                |                                                                                     |
+|----------------|-------------------------------------------------------------------------------------|
+| Key            | subject                                                                             |
+| Description    | An array of objects that references the subjects of the resource in ontology terms. |
+| Example        |                                                                                     |
+| Ontology Class |                                                                                     |
+| Badge          |                                                                                     |
+| Card.          | [*]                                                                                 |
+
+
+### Resource - subject (name)
+|                |                                                            |
+|----------------|------------------------------------------------------------|
+| Key            | name                                                       |
+| Description    | A class label of the ontology term.                        |
+| Example        | energy                                                     |
+| Ontology Class | [rdfs:label](https://www.w3.org/2000/01/rdf-schema#/label) |
+| Badge          | Platinum                                                   |
+| Card.          | [0..1]                                                     |
+
+
+### Resource - subject (@id)
+|                |                                                                                                              |
+|----------------|--------------------------------------------------------------------------------------------------------------|
+| Key            | @id                                                                                                          |
+| Description    | A unique identifier (URI/IRI) of the ontology class.                                                         |
+| Example        | [openenergyplatform.org/ontology/oeo/OEO_00000150](https://openenergyplatform.org/ontology/oeo/OEO_00000150) |
+| Ontology Class | [dct:subject](http://purl.org/dc/terms/subject)                                                              |
+| Badge          | Platinum                                                                                                     |
+| Card.          | [0..1]                                                                                                       |
+
+
+### Resource - keywords
+|                |                                                                                  |
+|----------------|----------------------------------------------------------------------------------|
+| Key            | keywords                                                                         |
+| Description    | An array of freely selectable keywords that help with searching and structuring. |
+| Example        | example, ODbL-1.0, NFDI4Energy                                                   |
+| Ontology Class | [dcat:keyword](http://www.w3.org/ns/dcat#keyword)                                |
+| Badge          | Silver                                                                           |
+| Card.          | [*]                                                                              |
+
+
+### Resource - publicationDate
+|                |                                                                                          |
+|----------------|------------------------------------------------------------------------------------------|
+| Key            | publicationDate                                                                          |
+| Description    | A date of publication of the data or metadata. The date format is ISO 8601 (YYYY-MM-DD). |
+| Example        | 2024-10-15                                                                               |
+| Ontology Class | [dct:issued](http://purl.org/dc/terms/issued)                                            |
+| Badge          | Bronze                                                                                   |
+| Card.          | [0..1]                                                                                   |
+
+
+### Resource - embargoPeriod
+|                |                                                                                                    |
+|----------------|----------------------------------------------------------------------------------------------------|
+| Key            | embargoPeriod                                                                                      |
+| Description    | An object that describes the embargo period during which public access to the data is not allowed. |
+| Example        |                                                                                                    |
+| Ontology Class |                                                                                                    |
+| Badge          |                                                                                                    |
+| Card.          | [0..1]                                                                                             |
+
+
+### Resource - embargoPeriod (start)
+|                |                                                                               |
+|----------------|-------------------------------------------------------------------------------|
+| Key            | start                                                                         |
+| Description    | The start date of the embargo period. The date of the data (metadata) upload. |
+| Example        | 2024-10-11                                                                    |
+| Ontology Class | [dbo:startDateTime](https://dbpedia.org/ontology/startDateTime)               |
+| Badge          | Bronze                                                                        |
+| Card.          | [0..1]                                                                        |
+
+
+### Resource - embargoPeriod (end)
+|                |                                                                              |
+|----------------|------------------------------------------------------------------------------|
+| Key            | end                                                                          |
+| Description    | The end date of the embargo period. This is the envisioned publication date. |
+| Example        | 2025-01-01                                                                   |
+| Ontology Class | [dbo:endDateTime](https://dbpedia.org/ontology/endDateTime)                  |
+| Badge          | Bronze                                                                       |
+| Card.          | [0..1]                                                                       |
+
+
+### Resource - embargoPeriod (isActive)
+|                |                                                                                                                                  |
+|----------------|----------------------------------------------------------------------------------------------------------------------------------|
+| Key            | isActive                                                                                                                         |
+| Description    | A boolean key that indicates if the embargo period is currently active. Must be changed to False on the embargo period end date. |
+| Example        | True                                                                                                                             |
+| Ontology Class | [adms:status](http://www.w3.org/ns/adms#status)                                                                                  |
+| Badge          | Bronze                                                                                                                           |
+| Card.          | [0..1]                                                                                                                           |
+
+### Resource - context
+|                |                                                                                                                                                                             |
+|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Key            | context                                                                                                                                                                     |
+| Description    | An object that describes the general setting, environment, or project leading to the creation or maintenance of this dataset. In science, this can be the research project. |
+| Example        |                                                                                                                                                                             |
+| Ontology Class |                                                                                                                                                                             |
+| Badge          |                                                                                                                                                                             |
+| Card.          | [0..1]                                                                                                                                                                      |
+
+
+### Resource - context (title)
+|                |                                             |
+|----------------|---------------------------------------------|
+| Key            | title                                       |
+| Description    | A title of the associated project.          |
+| Example        | NFDI4Energy                                 |
+| Ontology Class | [dct:title](http://purl.org/dc/terms/title) |
+| Badge          | Gold                                        |
+| Card.          | [0..1]                                      |
+
+### Resource - context (homepage)
+|                |                                                     |
+|----------------|-----------------------------------------------------|
+| Key            | homepage                                            |
+| Description    | A URL of the project.                               |
+| Example        | [nfdi4energy.uol.de](https://nfdi4energy.uol.de/)   |
+| Ontology Class | [foaf:homepage](http://xmlns.com/foaf/0.1/homepage) |
+| Badge          | Gold                                                |
+| Card.          | [0..1]                                              |
+
+
+### Resource - context (documentation)
+|                |                                                                                 |
+|----------------|---------------------------------------------------------------------------------|
+| Key            | documentation                                                                   |
+| Description    | A URL of the project documentation.                                             |
+| Example        | [nfdi4energy.uol.de/sites/about_us](https://nfdi4energy.uol.de/sites/about_us/) |
+| Ontology Class | [ncit:Project Description](http://purl.obolibrary.org/obo/NCIT_C165054)         |
+| Badge          | Gold                                                                            |
+| Card.          | [0..1]                                                                          |
+
+
+### Resource - context (sourceCode)
+|                |                                                                              |
+|----------------|------------------------------------------------------------------------------|
+| Key            | sourceCode                                                                   |
+| Description    | A URL of the source code of the project.                                     |
+| Example        | [github.com/NFDI4Energy](https://github.com/NFDI4Energy)                     |
+| Ontology Class | [oeo:code source](https://openenergyplatform.org/ontology/oeo/OEO_00000091/) |
+| Badge          | Gold                                                                         |
+| Card.          | [0..1]                                                                       |
+
+
+### Resource - context (publisher)
+|                |                                                         |
+|----------------|---------------------------------------------------------|
+| Key            | publisher                                               |
+| Description    | The publishing agency of the data. This can be the OEP. |
+| Example        | Open Energy Platform (OEP)                              |
+| Ontology Class | [dct:publisher](http://purl.org/dc/terms/publisher)     |
+| Badge          | Gold                                                    |
+| Card.          | [0..1]                                                  |
+
+
+### Resource - context (publisherLogo)
+|                |                                                                                                                                                                      |
+|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Key            | publisherLogo                                                                                                                                                        |
+| Description    | A URL to the logo of the publishing agency of data.                                                                                                                  |
+| Example        | [OpenEnergyFamily_Logo_OpenEnergyPlatform.svg](https://github.com/OpenEnergyPlatform/organisation/blob/production/logo/OpenEnergyFamily_Logo_OpenEnergyPlatform.svg) |
+| Ontology Class | [foaf:logo](http://xmlns.com/foaf/0.1/logo)                                                                                                                          |
+| Badge          | Gold                                                                                                                                                                 |
+| Card.          | [0..1]                                                                                                                                                               |
+
+
+### Resource - context (contact)
+|                |                                                                                                          |
+|----------------|----------------------------------------------------------------------------------------------------------|
+| Key            | contact                                                                                                  |
+| Description    | A reference to the creator or maintainer of the data set. It can be an email address or a GitHub handle. |
+| Example        | info@nfdi4energy.org                                                                                     |
+| Ontology Class | [oeo:contact person](https://openenergyplatform.org/ontology/oeo/OEO_00000107/)                          |
+| Badge          | Gold                                                                                                     |
+| Card.          | [0..1]                                                                                                   |
+
+
+### Resource - context (fundingAgency)
+|                |                                                                                           |
+|----------------|-------------------------------------------------------------------------------------------|
+| Key            | fundingAgency                                                                             |
+| Description    | A name of the entity providing the funding. This can be a government agency or a company. |
+| Example        | Deutsche Forschungsgemeinschaft (DFG)                                                     |
+| Ontology Class | [sc:FundingAgency](http://schema.org/fundingAgency)                                       |
+| Badge          | Gold                                                                                      |
+| Card.          | [0..1]                                                                                    |
+
+
+### Resource - context (fundingAgencyLogo)
+|                |                                                                                            |
+|----------------|--------------------------------------------------------------------------------------------|
+| Key            | fundingAgencyLogo                                                                          |
+| Description    | A URL to the logo or image of the funding agency.                                          |
+| Example        | [DFG-logo-blau.svg](https://upload.wikimedia.org/wikipedia/commons/8/86/DFG-logo-blau.svg) |
+| Ontology Class | [foaf:logo](http://xmlns.com/foaf/0.1/logo)                                                |
+| Badge          | Gold                                                                                       |
+| Card.          | [0..1]                                                                                     |
+
+
+### Resource - context (grantNo)
+|                |                                                                                                                   |
+|----------------|-------------------------------------------------------------------------------------------------------------------|
+| Key            | grantNo                                                                                                           |
+| Description    | An identifying grant number. In case of a publicly funded project, this number is assigned by the funding agency. |
+| Example        | 501865131                                                                                                         |
+| Ontology Class | [sc:Grant](http://schema.org/)                                                                                    |
+| Badge          | Gold                                                                                                              |
+| Card.          | [0..1]                                                                                                            |
+
+### Resource - spatial
+|                |                                                           |
+|----------------|-----------------------------------------------------------|
+| Key            | spatial                                                   |
+| Description    | An object that describes the spatial context of the data. |
+| Example        |                                                           |
+| Ontology Class |                                                           |
+| Badge          |                                                           |
+| Card.          | [0..1]                                                    |
+
+
+### Resource - spatial (location)
+|                |                                                   |
+|----------------|---------------------------------------------------|
+| Key            | location                                          |
+| Description    | An object that describes a specific location.     |
+| Example        |                                                   |
+| Ontology Class | [dct:location](http://purl.org/dc/terms/Location) |
+| Badge          |                                                   |
+| Card.          | [0..1]                                            |
+
+
+### Resource - spatial (location - address)
+|                |                                                                                                                   |
+|----------------|-------------------------------------------------------------------------------------------------------------------|
+| Key            | address                                                                                                           |
+| Description    | An address of the location of the data. May be specified with street name, house number, zip code, and city name. |
+| Example        | Rudower Chaussee 12, 12489 Berlin                                                                                 |
+| Ontology Class | [schema:address](https://schema.org/address)                                                                      |
+| Badge          | Silver                                                                                                            |
+| Card.          | [0..1]                                                                                                            |
+
+
+### Resource - spatial (location - @id)
+|                |                                                                             |
+|----------------|-----------------------------------------------------------------------------|
+| Key            | @id                                                                         |
+| Description    | A path or URI to a specific location. It can use Wikidata or OpenStreetMap. |
+| Example        | [www.wikidata.org/wiki/Q77077223](https://www.wikidata.org/wiki/Q77077223)  |
+| Ontology Class | [dct:identifier](http://purl.org/dc/terms/identifier)                       |
+| Badge          | Platinum                                                                    |
+| Card.          | [0..1]                                                                      |
+
+
+### Resource - spatial (location - latitude)
+|                |                                                 |
+|----------------|-------------------------------------------------|
+| Key            | latitude                                        |
+| Description    | The latitude (lat) information of the location. |
+| Example        | 52.432822                                       |
+| Ontology Class | [schema:latitude](https://schema.org/latitude)  |
+| Badge          | Gold                                            |
+| Card.          | [0..1]                                          |
+
+
+### Resource - spatial (location - longitude)
+|                |                                                  |
+|----------------|--------------------------------------------------|
+| Key            | longitude                                        |
+| Description    | The longitude (lon) information of the location. |
+| Example        | 13.5351004                                       |
+| Ontology Class | [schema:longitude](https://schema.org/longitude) |
+| Badge          | Gold                                             |
+| Card.          | [0..1]                                           |
+
+
+### Resource - spatial (extent)
+|                |                                                                  |
+|----------------|------------------------------------------------------------------|
+| Key            | extent                                                           |
+| Description    | An object that describes a covered area or region.               |
+| Example        |                                                                  |
+| Ontology Class | [oeo:spatial region](http://purl.obolibrary.org/obo/BFO_0000006) |
+| Badge          |                                                                  |
+| Card.          | [0..1]                                                           |
+
+
+### Resource - spatial (extent - name)
+|                |                                                            |
+|----------------|------------------------------------------------------------|
+| Key            | name                                                       |
+| Description    | The name of the region.                                    |
+| Example        | Berlin                                                     |
+| Ontology Class | [rdfs:label](https://www.w3.org/2000/01/rdf-schema#/label) |
+| Badge          | Silver                                                     |
+| Card.          | [0..1]                                                     |
+
+
+### Resource - spatial (extent - @id)
+|                |                                                                |
+|----------------|----------------------------------------------------------------|
+| Key            | @id                                                            |
+| Description    | A URI reference for the region.                                |
+| Example        | [www.wikidata.org/wiki/Q64](https://www.wikidata.org/wiki/Q64) |
+| Ontology Class | [dct:identifier](http://purl.org/dc/terms/identifier)          |
+| Badge          | Platinum                                                       |
+| Card.          | [0..1]                                                         |
+
+
+### Resource - spatial (extent - resolutionValue)
+|                |                                                                                       |
+|----------------|---------------------------------------------------------------------------------------|
+| Key            | resolutionValue                                                                       |
+| Description    | The value of the spatial resolution.                                                  |
+| Example        | 100                                                                                   |
+| Ontology Class | [dcat:spatialResolutionInMeters](http://www.w3.org/ns/dcat#spatialResolutionInMeters) |
+| Badge          | Silver                                                                                |
+| Card.          | [0..1]                                                                                |
+
+
+### Resource - spatial (extent - resolutionUnit)
+|                |                                                                     |
+|----------------|---------------------------------------------------------------------|
+| Key            | resolutionUnit                                                      |
+| Description    | The unit of the spatial resolution.                                 |
+| Example        | m                                                                   |
+| Ontology Class | [oeo:unit](http://openenergyplatform.org/ontology/oeo/OEO_00010489) |
+| Badge          | Silver                                                              |
+| Card.          | [0..1]                                                              |
+
+
+### Resource - spatial (extent - boundingBox)
+|                |                                                                                                                               |
+|----------------|-------------------------------------------------------------------------------------------------------------------------------|
+| Key            | boundingBox                                                                                                                   |
+| Description    | The covered area specified by the coordinates of a bounding box. The format is [minLon, minLat, maxLon, maxLat] or [W,S,E,N]. |
+| Example        | [13.08825, 52.33859, 13.76104, 52.6754]                                                                                       |
+| Ontology Class | [dcat:bbox](http://www.w3.org/ns/dcat#bbox)                                                                                   |
+| Badge          | Gold                                                                                                                          |
+| Card.          | [*]                                                                                                                           |
+
+
+### Resource - spatial (extent - crs)
+|                |                                                                                                                                          |
+|----------------|------------------------------------------------------------------------------------------------------------------------------------------|
+| Key            | crs                                                                                                                                      |
+| Description    | The Coordinate Reference System, specified as an EPSG code.                                                                              |
+| Example        | EPSG:4326                                                                                                                                |
+| Ontology Class | [cco:Geospatial Coordinate Reference System](http://www.ontologyrepository.com/CommonCoreOntologies/GeospatialCoordinateReferenceSystem) |
+| Badge          | Gold                                                                                                                                     |
+| Card.          | [0..1]                                                                                                                                   |
+
+### Resource - temporal
+|                |                                                                                                                                                             |
+|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Key            | temporal                                                                                                                                                    |
+| Description    | An object with the time period covered in the data. Temporal information should contain a "referenceDate" or the keys that describe a time series, or both. |
+| Example        |                                                                                                                                                             |
+| Ontology Class | [schema:temporalCoverage](https://schema.org/temporalCoverage)                                                                                              |
+| Badge          |                                                                                                                                                             |
+| Card.          | [0..1]                                                                                                                                                      |
+
+
+### Resource - temporal (referenceDate)
+|                |                                                                                                     |
+|----------------|-----------------------------------------------------------------------------------------------------|
+| Key            | referenceDate                                                                                       |
+| Description    | A base year, month or day. The time for which the data should be accurate. Date Format is ISO 8601. |
+| Example        | 2020-01-01                                                                                          |
+| Ontology Class | [dct:date](http://purl.org/dc/terms/date)                                                           |
+| Badge          | Silver                                                                                              |
+| Card.          | [0..1]                                                                                              |
+
+
+### Resource - temporal (timeseries)
+|                |                                                           |
+|----------------|-----------------------------------------------------------|
+| Key            | timeseries                                                |
+| Description    | An array that describes the timeseries.                   |
+| Example        |                                                           |
+| Ontology Class | [dct:PeriodOfTime](http://purl.org/dc/terms/PeriodOfTime) |
+| Badge          |                                                           |
+| Card.          | [*]                                                       |
+
+
+### Resource - temporal (timeseries - start)
+|                |                                                                 |
+|----------------|-----------------------------------------------------------------|
+| Key            | start                                                           |
+| Description    | The start time of a time series.                                |
+| Example        | 2020-01-01T00:00:00+00:00                                       |
+| Ontology Class | [dbo:startDateTime](https://dbpedia.org/ontology/startDateTime) |
+| Badge          | Silver                                                          |
+| Card.          | [0..1]                                                          |
+
+
+### Resource - temporal (timeseries - end)
+|                |                                                             |
+|----------------|-------------------------------------------------------------|
+| Key            | end                                                         |
+| Description    | The temporal end point of a time series.                    |
+| Example        | 2020-01-01T23:59:30+00:00                                   |
+| Ontology Class | [dbo:endDateTime](https://dbpedia.org/ontology/endDateTime) |
+| Badge          | Silver                                                      |
+| Card.          | [0..1]                                                      |
+
+
+### Resource - temporal (timeseries - resolutionValue)
+|                |                                                                                                    |
+|----------------|----------------------------------------------------------------------------------------------------|
+| Key            | resolutionValue                                                                                    |
+| Description    | The time span between individual information points in a time series. The value of the resolution. |
+| Example        | 30 s                                                                                               |
+| Ontology Class | [dcat:spatialResolutionInMeters](http://www.w3.org/ns/dcat#spatialResolutionInMeters)              |
+| Badge          | Silver                                                                                             |
+| Card.          | [0..1]                                                                                             |
+
+
+### Resource - temporal (timeseries - resolutionUnit)
+|                |                                                                     |
+|----------------|---------------------------------------------------------------------|
+| Key            | resolutionUnit                                                      |
+| Description    | The unit of the temporal resolution.                                |
+| Example        | 30 s                                                                |
+| Ontology Class | [oeo:unit](http://openenergyplatform.org/ontology/oeo/OEO_00010489) |
+| Badge          | Silver                                                              |
+| Card.          | [0..1]                                                              |
+
+
+### Resource - temporal (timeseries - alignment)
+|                |                                                                                              |
+|----------------|----------------------------------------------------------------------------------------------|
+| Key            | alignment                                                                                    |
+| Description    | An indicator of whether timestamps in a time series are to the left, right or in the centre. |
+| Example        | left                                                                                         |
+| Ontology Class | [oeo:time stamp alignment](http://openenergyplatform.org/ontology/oeo/OEO_00140044)          |
+| Badge          | Silver                                                                                       |
+| Card.          | [0..1]                                                                                       |
+
+
+### Resource - temporal (timeseries - aggregationType)
+|                |                                                                                   |
+|----------------|-----------------------------------------------------------------------------------|
+| Key            | aggregationType                                                                   |
+| Description    | An indicator of whether the values are a sum, an average or a current value.      |
+| Example        | current                                                                           |
+| Ontology Class | [oeo:aggregation type](https://openenergyplatform.org/ontology/oeo/OEO_00140068/) |
+| Badge          | Silver                                                                            |
+| Card.          | [0..1]                                                                            |
+
+### Resource - sources
+|                |                                                                                    |
+|----------------|------------------------------------------------------------------------------------|
+| Key            | sources                                                                            |
+| Description    | An array of objects with the used and underlying sources of the data and metadata. |
+| Example        |                                                                                    |
+| Ontology Class | [dct:source](http://purl.org/dc/terms/source)                                      |
+| Badge          |                                                                                    |
+| Card.          | [*]                                                                                |
+
+
+### Resource - sources (title)
+|                |                                                                              |
+|----------------|------------------------------------------------------------------------------|
+| Key            | title                                                                        |
+| Description    | A human readable title of the source, a document title or organisation name. |
+| Example        | IPCC Sixth Assessment Report (AR6) - Climate Change 2023 - Synthesis Report  |
+| Ontology Class | [dct:title](http://purl.org/dc/terms/title)                                  |
+| Badge          | Bronze                                                                       |
+| Card.          | [0..1]                                                                       |
+
+
+### Resource - sources (authors)
+|                |                                                                         |
+|----------------|-------------------------------------------------------------------------|
+| Key            | authors                                                                 |
+| Description    | An array of the full names of the authors of the source material.       |
+| Example        | Hoesung Lee, José Romero, The Core Writing Team                         |
+| Ontology Class | [oeo:author](https://openenergyplatform.org/ontology/oeo/OEO_00000064/) |
+| Badge          | Bronze                                                                  |
+| Card.          | [*]                                                                     |
+
+
+### Resource - sources (description)
+|                |                                                           |
+|----------------|-----------------------------------------------------------|
+| Key            | description                                               |
+| Description    | A free text description of the source.                    |
+| Example        | A Report of the Intergovernmental Panel on Climate Change |
+| Ontology Class | [dct:description](http://purl.org/dc/terms/description)   |
+| Badge          | Bronze                                                    |
+| Card.          | [0..1]                                                    |
+
+
+### Resource - sources (publicationYear)
+|                |                                                 |
+|----------------|-------------------------------------------------|
+| Key            | publicationYear                                 |
+| Description    | Indicates the year when the work was published. |
+| Example        | 2023                                            |
+| Ontology Class | [dct:issued](http://purl.org/dc/terms/issued)   |
+| Badge          | Bronze                                          |
+| Card.          | [0..1]                                          |
+
+
+### Resource - sources (path)
+|                |                                                                                                                |
+|----------------|----------------------------------------------------------------------------------------------------------------|
+| Key            | path                                                                                                           |
+| Description    | A DOI or link to the original source.                                                                          |
+| Example        | [IPCC_AR6_SYR_FullVolume.pdf](https://www.ipcc.ch/report/ar6/syr/downloads/report/IPCC_AR6_SYR_FullVolume.pdf) |
+| Ontology Class | [sc:url](https://schema.org/url)                                                                               |
+| Badge          | Bronze                                                                                                         |
+| Card.          | [0..1]                                                                                                         |
+
+
+### Resource - sourceLicenses
+|                |                                                                                                                                                                                                               |
+|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Key            | sourceLicenses                                                                                                                                                                                                |
+| Description    | An array of objects of licenses under which the described source is provided. See [academy/courses/08_licensing](https://openenergyplatform.github.io/academy/courses/08_licensing/) for further information. |
+| Example        |                                                                                                                                                                                                               |
+| Ontology Class | [dct:license](http://purl.org/dc/terms/license)                                                                                                                                                               |
+| Badge          |                                                                                                                                                                                                               |
+| Card.          | [*]                                                                                                                                                                                                           |
+
+
+### Resource - sourceLicenses (name)
+|                |                                                            |
+|----------------|------------------------------------------------------------|
+| Key            | name                                                       |
+| Description    | The [SPDX](https://spdx.org/licenses/) identifier.         |
+| Example        | ODbL-1.0                                                   |
+| Ontology Class | [rdfs:label](https://www.w3.org/2000/01/rdf-schema#/label) |
+| Badge          | Bronze                                                     |
+| Card.          | [0..1]                                                     |
+
+
+### Resource - sourceLicenses (title)
+|                |                                                     |
+|----------------|-----------------------------------------------------|
+| Key            | title                                               |
+| Description    | The official (human-readable) title of the license. |
+| Example        | Open Data Commons Open Database License 1.0         |
+| Ontology Class | [dct:title](http://purl.org/dc/terms/title)         |
+| Badge          | Bronze                                              |
+| Card.          | [0..1]                                              |
+
+
+### Resource - sourceLicenses (path)
+|                |                                                                                                              |
+|----------------|--------------------------------------------------------------------------------------------------------------|
+| Key            | path                                                                                                         |
+| Description    | A link or path to the license text.                                                                          |
+| Example        | [opendatacommons.org/licenses/odbl/1-0/index.html](https://opendatacommons.org/licenses/odbl/1-0/index.html) |
+| Ontology Class | [sc:url](https://schema.org/url)                                                                             |
+| Badge          | Bronze                                                                                                       |
+| Card.          | [0..1]                                                                                                       |
+
+
+### Resource - sourceLicenses (instruction)
+|                |                                                                                                                                                                                                                    |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Key            | instruction                                                                                                                                                                                                        |
+| Description    | A short description of rights and obligations. The use of [tl;drLegal](https://tldrlegal.com/) is recommended.                                                                                                     |
+| Example        | You are free to share and change, but you must attribute, and share derivations under the same license. See [tldrlegal.com](https://tldrlegal.com/license/odc-open-database-license-odbl) for further information. |
+| Ontology Class | [rdfs:comment](https://www.w3.org/2000/01/rdf-schema#comment)                                                                                                                                                      |
+| Badge          | Bronze                                                                                                                                                                                                             |
+| Card.          | [0..1]                                                                                                                                                                                                             |
+
+
+### Resource - sourceLicenses (attribution)
+|                |                                                                                         |
+|----------------|-----------------------------------------------------------------------------------------|
+| Key            | attribution                                                                             |
+| Description    | A copyright owner of the **source**. Must be provided if attribution licenses are used. |
+| Example        | © Intergovernmental Panel on Climate Change 2023                                        |
+| Ontology Class | [ms:copyright notice](http://purl.obolibrary.org/obo/MS_1003198)                        |
+| Badge          | Bronze                                                                                  |
+| Card.          | [0..1]                                                                                  |
+
+
+### Resource - sourceLicenses (copyrightStatement)
+|                |                                                                                                                               |
+|----------------|-------------------------------------------------------------------------------------------------------------------------------|
+| Key            | copyrightStatement                                                                                                            |
+| Description    | A link or path that proves that the source or data has the appropriate license. This can be a page number or website imprint. |
+| Example        | [www.ipcc.ch/copyright](https://www.ipcc.ch/copyright/)                                                                       |
+| Ontology Class | [dct:rights](http://purl.org/dc/terms/rights)                                                                                 |
+| Badge          | Bronze                                                                                                                        |
+| Card.          | [0..1]                                                                                                                        |
+
+### Resource - licenses
+|                |                                                                             |
+|----------------|-----------------------------------------------------------------------------|
+| Key            | licenses                                                                    |
+| Description    | An array of objects of licenses under which the described data is provided. |
+| Example        |                                                                             |
+| Ontology Class | [dct:license](http://purl.org/dc/terms/license)                             |
+| Badge          |                                                                             |
+| Card.          | [*]                                                                         |
+
+
+### Resource - licenses (name)
+|                |                                                            |
+|----------------|------------------------------------------------------------|
+| Key            | name                                                       |
+| Description    | The [SPDX](https://spdx.org/licenses/) identifier.         |
+| Example        | ODbL-1.0                                                   |
+| Ontology Class | [rdfs:label](https://www.w3.org/2000/01/rdf-schema#/label) |
+| Badge          | Bronze                                                     |
+| Card.          | [0..1]                                                     |
+
+
+### Resource - licenses (title)
+|                |                                                     |
+|----------------|-----------------------------------------------------|
+| Key            | title                                               |
+| Description    | The official (human-readable) title of the license. |
+| Example        | Open Data Commons Open Database License 1.0         |
+| Ontology Class | [dct:title](http://purl.org/dc/terms/title)         |
+| Badge          | Bronze                                              |
+| Card.          | [0..1]                                              |
+
+
+### Resource - licenses (path)
+|                |                                                                                                              |
+|----------------|--------------------------------------------------------------------------------------------------------------|
+| Key            | path                                                                                                         |
+| Description    | A link or path to the license text.                                                                          |
+| Example        | [opendatacommons.org/licenses/odbl/1-0/index.html](https://opendatacommons.org/licenses/odbl/1-0/index.html) |
+| Ontology Class | [dcat:accessURL](https://www.w3.org/ns/dcat#accessURL)                                                       |
+| Badge          | Bronze                                                                                                       |
+| Card.          | [0..1]                                                                                                       |
+
+
+### Resource - licenses (instruction)
+|                |                                                                                                                                                                                                                    |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Key            | instruction                                                                                                                                                                                                        |
+| Description    | A short description of rights and obligations. The use of [tl;drLegal](https://tldrlegal.com/) is recommended.                                                                                                     |
+| Example        | You are free to share and change, but you must attribute, and share derivations under the same license. See [tldrlegal.com](https://tldrlegal.com/license/odc-open-database-license-odbl) for further information. |
+| Ontology Class | [dc:rights](http://purl.org/dc/elements/1.1/rights)                                                                                                                                                                |
+| Badge          | Bronze                                                                                                                                                                                                             |
+| Card.          | [0..1]                                                                                                                                                                                                             |
+
+
+### Resource - licenses (attribution)
+|                |                                                                                       |
+|----------------|---------------------------------------------------------------------------------------|
+| Key            | attribution                                                                           |
+| Description    | A copyright owner of the **data**. Must be provided if attribution licenses are used. |
+| Example        | © Reiner Lemoine Institut                                                             |
+| Ontology Class | [spdx:attributionText](http://spdx.org/rdf/terms#attributionText)                     |
+| Badge          | Bronze                                                                                |
+| Card.          | [0..1]                                                                                |
+
+
+### Resource - licenses (copyrightStatement)
+|                |                                                                                                                     |
+|----------------|---------------------------------------------------------------------------------------------------------------------|
+| Key            | copyrightStatement                                                                                                  |
+| Description    | A link or path that proves that the data has the appropriate license. This can be a page number or website imprint. |
+| Example        | [www.ipcc.ch/copyright/](https://www.ipcc.ch/copyright/)                                                            |
+| Ontology Class | [dct:rights](http://purl.org/dc/terms/rights)                                                                       |
+| Badge          | Bronze                                                                                                              |
+| Card.          | [0..1]                                                                                                              |
+
+### Resource - Provenance Keys
+|                |                                                                                                                                                                 |
+|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Key            | contributors                                                                                                                                                    |
+| Description    | An array of objects of the people or organizations who contributed to the data or metadata. Should have "Date of data creation" and "Date of metadata creation" |
+| Example        |                                                                                                                                                                 |
+| Ontology Class | [foaf:Agent](http://xmlns.com/foaf/0.1/Agent)                                                                                                                   |
+| Badge          |                                                                                                                                                                 |
+| Card.          | [*]                                                                                                                                                             |
+
+
+### Resource - Provenance Keys (title)
+|                |                                             |
+|----------------|---------------------------------------------|
+| Key            | title                                       |
+| Description    | A full name of the contributor.             |
+| Example        | Ludwig Hülk                                 |
+| Ontology Class | [dct:title](http://purl.org/dc/terms/title) |
+| Badge          | Bronze                                      |
+| Card.          | [0..1]                                      |
+
+
+### Resource - Provenance Keys (path)
+|                |                                                                                                                            |
+|----------------|----------------------------------------------------------------------------------------------------------------------------|
+| Key            | path                                                                                                                       |
+| Description    | A qualified link or path pointing to a relevant location online for the contributor. This can be the GitHub page or ORCID. |
+| Example        | https://github.com/Ludee                                                                                                   |
+| Ontology Class | [sc:url](https://schema.org/url)                                                                                           |
+| Badge          | Bronze                                                                                                                     |
+| Card.          | [0..1]                                                                                                                     |
+
+
+### Resource - Provenance Keys (organization)
+|                |                                                                                                                 |
+|----------------|-----------------------------------------------------------------------------------------------------------------|
+| Key            | organization                                                                                                    |
+| Description    | A string describing the organization this contributor is affiliated to. This can be relevant for the copyright. |
+| Example        | Reiner Lemoine Institut                                                                                         |
+| Ontology Class | [oeo:organisation](https://openenergyplatform.org/ontology/oeo/OEO_00030022/)                                   |
+| Badge          | Bronze                                                                                                          |
+| Card.          | [0..1]                                                                                                          |
+
+
+### Resource - Provenance Keys (roles)
+|                |                                                                                                                                                                                                                                                                                    |
+|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Key            | roles                                                                                                                                                                                                                                                                              |
+| Description    | An array describing the roles of the contributor. A role is recommended to follow the established vocabulary: [DataCite Metadata Schema’s contributorRole](https://support.datacite.org/docs/datacite-metadata-schema-v44-recommended-and-optional-properties#7a-contributortype). |
+| Example        | DataCollector, DataCurator                                                                                                                                                                                                                                                         |
+| Ontology Class | [oeo:role](https://openenergyplatform.org/ontology/oeo/BFO_0000023/)                                                                                                                                                                                                               |
+| Badge          | Bronze                                                                                                                                                                                                                                                                             |
+| Card.          | [*]                                                                                                                                                                                                                                                                                |
+
+
+### Resource - Provenance Keys (date)
+|                |                                                        |
+|----------------|--------------------------------------------------------|
+| Key            | date                                                   |
+| Description    | The date of the contribution. Date Format is ISO 8601. |
+| Example        | 2024-10-21                                             |
+| Ontology Class | [dct:issued](http://purl.org/dc/terms/issued)          |
+| Badge          | Bronze                                                 |
+| Card.          | [0..1]                                                 |
+
+
+### Resource - Provenance Keys (object)
+|                |                                                                                                 |
+|----------------|-------------------------------------------------------------------------------------------------|
+| Key            | object                                                                                          |
+| Description    | The target of the contribution. This can be the data, the metadata or both (data and metadata). |
+| Example        | data and metadata                                                                               |
+| Ontology Class | [dct:type](http://purl.org/dc/terms/type)                                                       |
+| Badge          | Bronze                                                                                          |
+| Card.          | [0..1]                                                                                          |
+
+
+### Resource - Provenance Keys (comment)
+|                |                                                               |
+|----------------|---------------------------------------------------------------|
+| Key            | comment                                                       |
+| Description    | A free-text commentary on what has been done.                 |
+| Example        | Add general context.                                          |
+| Ontology Class | [rdfs:comment](https://www.w3.org/2000/01/rdf-schema#comment) |
+| Badge          | Bronze                                                        |
+| Card.          | [0..1]                                                        |
+
+### Resource - Type Keys
+
+| Key            | type                                                                                                   |
+|----------------|--------------------------------------------------------------------------------------------------------|
+| Description    | The 'table' type indicates that the resource is tabular as per 'Frictionless Tabular Data' definition. |
+| Example        | table                                                                                                  |
+| Ontology Class | [csvw:datatype](https://www.w3.org/ns/csvw#datatype)                                                   |
+| Badge          | Gold                                                                                                   |
+| Card.          | [0..1]                                                                                                 |
+
+
+| Key            | format                                                                                                                          |
+|----------------|---------------------------------------------------------------------------------------------------------------------------------|
+| Description    | A file extension format. Possible options are 'csv', 'xlsx', 'json', 'PostgreSQL', 'SQLite' and other standard file extensions. |
+| Example        | PostgreSQL                                                                                                                      |
+| Ontology Class | [dct:format](http://purl.org/dc/terms/format)                                                                                   |
+| Badge          | Gold                                                                                                                            |
+| Card.          | [0..1]                                                                                                                          |
+
+
+| Key            | encoding                                                                                                                                      |
+|----------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
+| Description    | Specifies the character encoding of the resource's data file. The default is 'UTF-8'. The values should be one of the 'Preferred MIME Names'. |
+| Example        | UTF-8                                                                                                                                         |
+| Ontology Class | [csvw:encoding](http://www.w3.org/ns/csvw#encoding)                                                                                           |
+| Badge          | Gold                                                                                                                                          |
+| Card.          | [0..1]                                                                                                                                        |
+
+### Resource - Fields Keys
+
+|                |                                                                                                                                              |
+|----------------|----------------------------------------------------------------------------------------------------------------------------------------------|
+| Key            | **schema**                                                                                                                                   |
+| Description    | An object that describes the structure of a table. It contains all fields (columns of the table), the primary key and optional foreign keys. |
+| Example        |                                                                                                                                              |
+| Ontology Class | [schema:table](https://schema.org/Table)                                                                                                     |
+| Badge          |                                                                                                                                              |
+| Card.          | [1]                                                                                                                                          |
+
+
+### Resource - Fields Keys - fields
+
+|                |                                                                                   |
+|----------------|-----------------------------------------------------------------------------------|
+| Key            | **fields**                                                                        |
+| Description    | An array of objects that describes a field (column) and its detailed information. |
+| Example        |                                                                                   |
+| Ontology Class | [csvw:column](http://www.w3.org/ns/csvw#column)                                   |
+| Badge          |                                                                                   |
+| Card.          | [1]                                                                               |
+
+
+### Resource - Fields Keys - name
+
+|                |                                                                                                                                                         |
+|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Key            | **name**                                                                                                                                                |
+| Description    | The name of the field. The name may only consist of lowercase alphanumeric characters or underscores. It must not begin with a number or an underscore. |
+| Example        | year                                                                                                                                                    |
+| Ontology Class | [rdfs:label](https://www.w3.org/2000/01/rdf-schema#/label)                                                                                              |
+| Badge          | Iron                                                                                                                                                    |
+| Card.          | [1]                                                                                                                                                     |
+
+
+### Resource - Fields Keys - description
+
+|                |                                                         |
+|----------------|---------------------------------------------------------|
+| Key            | **description**                                         |
+| Description    | A text describing the field.                            |
+| Example        | Reference year for which the data were collected.       |
+| Ontology Class | [dct:description](http://purl.org/dc/terms/description) |
+| Badge          | Silver                                                  |
+| Card.          | [0..1]                                                  |
+
+
+### Resource - Fields Keys - type
+
+|                |                                                                                                      |
+|----------------|------------------------------------------------------------------------------------------------------|
+| Key            | **type**                                                                                             |
+| Description    | The data type of the field. In case of a geom column in a database, also indicate the shape and CRS. |
+| Example        | geometry(Point, 4326)                                                                                |
+| Ontology Class | [csvw:datatype](https://www.w3.org/ns/csvw#datatype)                                                 |
+| Badge          | Iron                                                                                                 |
+| Card.          | [1]                                                                                                  |
+
+
+### Resource - Fields Keys - nullable
+
+|                |                                                                                    |
+|----------------|------------------------------------------------------------------------------------|
+| Key            | **nullable**                                                                       |
+| Description    | A boolean key to specify that a column can be nullable. True is the default value. |
+| Example        | True                                                                               |
+| Ontology Class | [ncit:null](http://purl.obolibrary.org/obo/NCIT_C47840)                            |
+| Badge          | Iron                                                                               |
+| Card.          | [1]                                                                                |
+
+
+### Resource - Fields Keys - unit
+
+|                |                                                                                                                                                                                     |
+|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Key            | **unit**                                                                                                                                                                            |
+| Description    | The unit of a field. If it does not apply, use 'null'. If the unit is given in a separate field, reference this field (e.g. 'unit'). Use a space between numbers and units (100 m). |
+| Example        | MW                                                                                                                                                                                  |
+| Ontology Class | [oeo:has unit](https://openenergyplatform.org/ontology/oeo/OEO_00040010/)                                                                                                           |
+| Badge          | Silver                                                                                                                                                                              |
+| Card.          | [0..1]                                                                                                                                                                              |
+
+
+### Resource - Fields Keys - isAbout
+
+|                |                                                                 |
+|----------------|-----------------------------------------------------------------|
+| Key            | **isAbout**                                                     |
+| Description    | An array of objects that describes the field in ontology terms. |
+| Example        |                                                                 |
+| Ontology Class | [sc:about](https://schema.org/about)                            |
+| Badge          |                                                                 |
+| Card.          | [*]                                                             |
+
+
+### Resource - Fields Keys - name (isAbout)
+
+|                |                                                            |
+|----------------|------------------------------------------------------------|
+| Key            | **name**                                                   |
+| Description    | The class label of the ontology term.                      |
+| Example        | wind energy converting unit                                |
+| Ontology Class | [rdfs:label](https://www.w3.org/2000/01/rdf-schema#/label) |
+| Badge          | Platinum                                                   |
+| Card.          | [0..1]                                                     |
+
+
+### Resource - Fields Keys - @id (isAbout)
+
+|                |                                                                          |
+|----------------|--------------------------------------------------------------------------|
+| Key            | **@id**                                                                  |
+| Description    | The path of the ontology term (IRI).                                     |
+| Example        | [OEO_00000044](https://openenergyplatform.org/ontology/oeo/OEO_00000044) |
+| Ontology Class | [dct:identifier](http://purl.org/dc/terms/identifier)                    |
+| Badge          | Platinum                                                                 |
+| Card.          | [0..1]                                                                   |
+
+
+### Resource - Fields Keys - valueReference
+
+|                |                                                                                                |
+|----------------|------------------------------------------------------------------------------------------------|
+| Key            | **valueReference**                                                                             |
+| Description    | An array of objects for an extended description of the values in the column in ontology terms. |
+| Example        |                                                                                                |
+| Ontology Class | [prov:value](https://www.w3.org/ns/prov#value)                                                 |
+| Badge          |                                                                                                |
+| Card.          | [*]                                                                                            |
+
+
+### Resource - Fields Keys - value
+
+|                |                                                                |
+|----------------|----------------------------------------------------------------|
+| Key            | **value**                                                      |
+| Description    | The name of the value in the column.                           |
+| Example        | onshore                                                        |
+| Ontology Class | [rdf:value](https://www.w3.org/1999/02/22-rdf-syntax-ns#value) |
+| Badge          | Platinum                                                       |
+| Card.          | [0..1]                                                         |
+
+
+### Resource - Fields Keys - name (valueReference)
+
+|                |                                                            |
+|----------------|------------------------------------------------------------|
+| Key            | **name**                                                   |
+| Description    | The class label of the ontology term in the column.        |
+| Example        | onshore wind farm                                          |
+| Ontology Class | [rdfs:label](https://www.w3.org/2000/01/rdf-schema#/label) |
+| Badge          | Platinum                                                   |
+| Card.          | [0..1]                                                     |
+
+
+### Resource - Fields Keys - @id (valueReference)
+
+|                |                                                                          |
+|----------------|--------------------------------------------------------------------------|
+| Key            | **@id**                                                                  |
+| Description    | The path of the ontology term (IRI) in the column.                       |
+| Example        | [OEO_00000311](https://openenergyplatform.org/ontology/oeo/OEO_00000311) |
+| Ontology Class | [dct:identifier](http://purl.org/dc/terms/identifier)                    |
+| Badge          | Platinum                                                                 |
+| Card.          | [0..1]                                                                   |
+
+### Resource - Properties Keys
+
+|                |                                                                                                          |
+|----------------|----------------------------------------------------------------------------------------------------------|
+| Key            | **primaryKey**                                                                                           |
+| Description    | An array of fields that uniquely identifies each row in the table. The default value is the “id” column. |
+| Example        | id                                                                                                       |
+| Ontology Class | [csvw:primaryKey](https://www.w3.org/ns/csvw#primaryKey)                                                 |
+| Badge          | Iron                                                                                                     |
+| Card.          | [1..*]                                                                                                   |
+
+
+### Resource - Properties Keys - foreignKeys
+
+|                |                                                                                                       |
+|----------------|-------------------------------------------------------------------------------------------------------|
+| Key            | **foreignKeys**                                                                                       |
+| Description    | An array of objects with foreign keys that describe a field that relates to a field in another table. |
+| Example        |                                                                                                       |
+| Ontology Class | [csvw:foreignKey](https://www.w3.org/ns/csvw#foreignKey)                                              |
+| Badge          |                                                                                                       |
+| Card.          | [*]                                                                                                   |
+
+
+### Resource - Properties Keys - fields (foreignKeys)
+
+|                |                                                                         |
+|----------------|-------------------------------------------------------------------------|
+| Key            | **fields**                                                              |
+| Description    | An array of fields in the table that is constrained by the foreign key. |
+| Example        | id, version                                                             |
+| Ontology Class | [ex:nestedFields](http://example.org/nestedFields)                      |
+| Badge          | Iron                                                                    |
+| Card.          | [*]                                                                     |
+
+
+### Resource - Properties Keys - reference
+
+|                |                                     |
+|----------------|-------------------------------------|
+| Key            | **reference**                       |
+| Description    | The reference to the foreign table. |
+| Example        |                                     |
+| Ontology Class |                                     |
+| Badge          |                                     |
+| Card.          | [0..1]                              |
+
+
+### Resource - Properties Keys - resource (reference)
+
+|                |                                                    |
+|----------------|----------------------------------------------------|
+| Key            | **resource**                                       |
+| Description    | The referenced foreign table.                      |
+| Example        | model_draft.oep_oemetadata_table_example_version   |
+| Ontology Class | [dcat:Dataset](https://www.w3.org/ns/dcat#dataset) |
+| Badge          | Iron                                               |
+| Card.          | [0..1]                                             |
+
+
+### Resource - Properties Keys - fields (reference)
+
+|                |                                                 |
+|----------------|-------------------------------------------------|
+| Key            | **fields**                                      |
+| Description    | The foreign resource column.                    |
+| Example        | id, version                                     |
+| Ontology Class | [csvw:column](http://www.w3.org/ns/csvw#column) |
+| Badge          | Iron                                            |
+| Card.          | [*]                                             |
+
+
+### Resource - Properties Keys - dialect
+
+|                |                                                                                                                                                                            |
+|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Key            | **dialect**                                                                                                                                                                |
+| Description    | The Dialect defines a simple format for describing the various dialects of CSV files in a language-independent manner. In a database, the values in the fields are 'null'. |
+| Example        |                                                                                                                                                                            |
+| Ontology Class |                                                                                                                                                                            |
+| Badge          |                                                                                                                                                                            |
+| Card.          | [1]                                                                                                                                                                        |
+
+
+### Resource - Properties Keys - delimiter
+
+|                |                                                                                                                                                                        |
+|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Key            | **delimiter**                                                                                                                                                          |
+| Description    | The delimiter specifies the character sequence which should separate fields (columns). Common characters are ',' (comma), ';' (semicolon), '.' (point) and '\t' (tab). |
+| Example        | ,                                                                                                                                                                      |
+| Ontology Class | [csvw:delimiter](http://www.w3.org/ns/csvw#delimiter)                                                                                                                  |
+| Badge          | Iron                                                                                                                                                                   |
+| Card.          | [1]                                                                                                                                                                    |
+
+
+### Resource - Properties Keys - decimalSeparator
+
+|                |                                                                                                                                                                            |
+|----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Key            | **decimalSeparator**                                                                                                                                                       |
+| Description    | The symbol used to separate the integer part from the fractional part of a number written in decimal form. Depending on language and region this symbol can be '.' or ','. |
+| Example        | .                                                                                                                                                                          |
+| Ontology Class | [csvw:decimalChar](http://www.w3.org/ns/csvw#decimalChar)                                                                                                                  |
+| Badge          | Iron                                                                                                                                                                       |
+| Card.          | [1]                                                                                                                                                                        |
+
+### Resource - Review Keys
+
+|                |                                                                                                                                                                                                              |
+|----------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Key            | **review**                                                                                                                                                                                                   |
+| Description    | The metadata on the OEP can go through an open peer review process. See the Academy course [Open Peer Review](https://openenergyplatform.github.io/academy/courses/09_peer_review/) for further information. |
+| Example        |                                                                                                                                                                                                              |
+| Ontology Class |                                                                                                                                                                                                              |
+| Badge          | [0..1]                                                                                                                                                                                                       |
+
+
+### Resource - Review Keys - path
+
+|                |                                                                                                                      |
+|----------------|----------------------------------------------------------------------------------------------------------------------|
+| Key            | **path**                                                                                                             |
+| Description    | A link or path to the documented open peer review.                                                                   |
+| Example        | [open_peer_review/9](https://openenergyplatform.org/dataedit/view/model_draft/oep_table_example/open_peer_review/9/) |
+| Ontology Class | [sc:url](https://schema.org/url)                                                                                     |
+| Badge          | [0..1]                                                                                                               |
+
+
+### Resource - Review Keys - badge
+
+|                |                                                                                                        |
+|----------------|--------------------------------------------------------------------------------------------------------|
+| Key            | **badge**                                                                                              |
+| Description    | A badge of either Iron, Bronze, Silver, Gold or Platinum is used to label the quality of the metadata. |
+| Example        | Platinum                                                                                               |
+| Ontology Class | [oeo:quality control flag](https://openenergyplatform.org/ontology/oeo/OEO_00140098/)                  |
+| Badge          | [0..1]                                                                                                 |
+
+### MetaMetadata Keys
+
+|                |                                                                                      |
+|----------------|--------------------------------------------------------------------------------------|
+| Key            | **metaMetadata**                                                                     |
+| Description    | An object that describes the metadata themselves, their format, version and license. |
+| Example        |                                                                                      |
+| Ontology Class |                                                                                      |
+| Card.          | [1]                                                                                  |
+
+
+### MetaMetadata Keys - metadataVersion
+
+|                |                                                              |
+|----------------|--------------------------------------------------------------|
+| Key            | **metadataVersion**                                          |
+| Description    | Type and version number of the metadata.                     |
+| Example        | OEMetadata-2.0                                               |
+| Ontology Class | [owl:versionInfo](http://www.w3.org/2002/07/owl#versionInfo) |
+| Card.          | [1]                                                          |
+
+
+### MetaMetadata Keys - metadataLicense
+
+|                |                                                 |
+|----------------|-------------------------------------------------|
+| Key            | **metadataLicense**                             |
+| Description    | The license of the provided metadata.           |
+| Example        |                                                 |
+| Ontology Class | [dct:license](http://purl.org/dc/terms/license) |
+| Card.          | [1]                                             |
+
+
+### MetaMetadata Keys - metadataLicense - name
+
+|                |                                                            |
+|----------------|------------------------------------------------------------|
+| Key            | **name**                                                   |
+| Description    | The [SPDX](https://spdx.org/licenses/) identifier.         |
+| Example        | CC0-1.0                                                    |
+| Ontology Class | [rdfs:label](https://www.w3.org/2000/01/rdf-schema#/label) |
+| Card.          | [1]                                                        |
+
+
+### MetaMetadata Keys - metadataLicense - title
+
+|                |                                                     |
+|----------------|-----------------------------------------------------|
+| Key            | **title**                                           |
+| Description    | The official (human-readable) title of the license. |
+| Example        | Creative Commons Zero v1.0 Universal                |
+| Ontology Class | [dct:title](http://purl.org/dc/terms/title)         |
+| Card.          | [1]                                                 |
+
+
+### MetaMetadata Keys - metadataLicense - path
+
+|                |                                                                                                  |
+|----------------|--------------------------------------------------------------------------------------------------|
+| Key            | **path**                                                                                         |
+| Description    | A link or path to the license text.                                                              |
+| Example        | [creativecommons.org/publicdomain/zero/1.0/](https://creativecommons.org/publicdomain/zero/1.0/) |
+| Ontology Class | [sc:url](https://schema.org/url)                                                                 |
+| Card.          | [1]                                                                                              |

--- a/oemetadata/v2/v21/schema.json
+++ b/oemetadata/v2/v21/schema.json
@@ -1,0 +1,1505 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/v2/v20/schema.json",
+  "description": "Open Energy Metadata (OEMetadata) - metadata schema",
+  "type": "object",
+  "required": [
+    "resources"
+  ],
+  "properties": {
+    "@context": {
+      "description": "Explanation of metadata keys in ontology terms.",
+      "examples": [
+        "https://raw.githubusercontent.com/OpenEnergyPlatform/oemetadata/production/oemetadata/latest/context.json"
+      ],
+      "type": [
+        "string",
+        "null"
+      ],
+      "badge": "Platinum",
+      "title": "@context",
+      "readOnly": true
+    },
+    "name": {
+      "description": "A filename or database conform dataset name.",
+      "type": [
+        "string",
+        "null"
+      ],
+      "examples": [
+        "oep_oemetadata"
+      ],
+      "badge": "Iron",
+      "title": "Dataset Name"
+    },
+    "title": {
+      "description": "A human readable dataset name.",
+      "type": [
+        "string",
+        "null"
+      ],
+      "examples": [
+        "OEP OEMetadata"
+      ],
+      "badge": "Bronze",
+      "title": "Dataset Title"
+    },
+    "description": {
+      "description": "A free text description of the dataset.",
+      "type": [
+        "string",
+        "null"
+      ],
+      "examples": [
+        "A dataset for the OEMetadata examples."
+      ],
+      "badge": "Bronze",
+      "title": "Dataset Description"
+    },
+    "@id": {
+      "description": "A unique identifier (UUID/DOI) for the collection.",
+      "type": [
+        "string",
+        "null"
+      ],
+      "examples": [
+        "https://databus.openenergyplatform.org/oeplatform/supply/wri_global_power_plant_database/"
+      ],
+      "badge": "Platinum",
+      "title": "Dataset Identifier",
+      "format": "uri",
+      "readOnly": true
+    },
+    "resources": {
+      "description": "A collection of related resources.",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "@id": {
+            "description": "A Uniform Resource Identifier (URI) that links the resource via the OpenEnergyDatabus (DBpedia Databus).",
+            "type": [
+              "string",
+              "null"
+            ],
+            "examples": [
+              "https://databus.openenergyplatform.org/oeplatform/supply/wri_global_power_plant_database/2022-11-07/wri_global_power_plant_database_variant=data.csv"
+            ],
+            "badge": "Platinum",
+            "title": "@Id",
+            "readOnly": true
+          },
+          "name": {
+            "description": "A filename or database conform table name.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "examples": [
+              "oemetadata_table_template"
+            ],
+            "badge": "Iron",
+            "title": "Name"
+          },
+          "topics": {
+            "description": "An array of predefined topics that correspond to the database schemas of the OEP.",
+            "type": "array",
+            "items": {
+              "description": "The topics are used to group the data in the database.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "examples": [
+                "model_draft"
+              ],
+              "badge": "Bronze",
+              "title": "Topic"
+            },
+            "badge": "Bronze",
+            "title": "Topics"
+          },
+          "title": {
+            "description": "A human readable resource or table name.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "examples": [
+              "OEMetadata Table Template"
+            ],
+            "badge": "Silver",
+            "title": "Title"
+          },
+          "path": {
+            "description": "A unique identifier (URI/UUID/DOI) for the table or file.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "examples": [
+              "http://openenergyplatform.org/dataedit/view/model_draft/oemetadata_table_template"
+            ],
+            "badge": "Bronze",
+            "title": "Path",
+            "readOnly": true
+          },
+          "description": {
+            "description": "A description of the table. It should be usable as summary information for the table that is described by the metadata.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "examples": [
+              "Example table used to illustrate the OEMetadata structure and features."
+            ],
+            "badge": "Silver",
+            "title": "Description"
+          },
+          "languages": {
+            "description": "An array of languages used within the described data structures (e.g. titles, descriptions) or metadata.",
+            "type": "array",
+            "items": {
+              "description": "The language keys must follow the Standard IETF (BCP47) and can be repeated if more languages are used.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "examples": [
+                "en-GB",
+                "de-DE"
+              ],
+              "badge": "Gold",
+              "title": "Language"
+            },
+            "badge": "Gold",
+            "title": "Languages"
+          },
+          "subject": {
+            "description": "An array of objects that references to the subjects of the resource in ontology terms.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "description": "A class label of the ontology term.",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "examples": [
+                    "energy"
+                  ],
+                  "badge": "Platinum",
+                  "title": "Subject Name"
+                },
+                "@id": {
+                  "description": "A unique identifier (URI/IRI) of the ontology class.",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "examples": [
+                    "https://openenergyplatform.org/ontology/oeo/OEO_00000150"
+                  ],
+                  "badge": "Platinum",
+                  "title": "Subject Identifier",
+                  "format": "uri"
+                }
+              },
+              "badge": "Platinum",
+              "title": "Subject"
+            },
+            "badge": "Platinum",
+            "title": "Subject"
+          },
+          "keywords": {
+            "description": "An array of freely selectable keywords that help with searching and structuring.",
+            "type": "array",
+            "items": {
+              "description": "The keyword are used and managed in the OEP as table tags.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "examples": [
+                "example",
+                "ODbL-1.0",
+                "NFDI4Energy"
+              ],
+              "badge": "Silver",
+              "title": "Keyword"
+            },
+            "badge": "Silver",
+            "title": "Keywords"
+          },
+          "publicationDate": {
+            "description": "A date of publication of the data or metadata. The date format is ISO 8601 (YYYY-MM-DD).",
+            "type": [
+              "string",
+              "null"
+            ],
+            "examples": [
+              "2024-10-15"
+            ],
+            "badge": "Bronze",
+            "title": "Publication Date",
+            "format": "date"
+          },
+          "embargoPeriod": {
+            "description": "An object that describes the embargo period during which public access to the data is not allowed.",
+            "type": "object",
+            "properties": {
+              "start": {
+                "description": "The start date of the embargo period. The date of the data (metadata) upload.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "examples": [
+                  "2024-10-11"
+                ],
+                "badge": "Bronze",
+                "title": "Embargo Period Start",
+                "format": "date"
+              },
+              "end": {
+                "description": "The end date of the embargo period. This is the intended publication date.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "examples": [
+                  "2025-01-01"
+                ],
+                "badge": "Bronze",
+                "title": "Embargo Period End (Publication Date)",
+                "format": "date"
+              },
+              "isActive": {
+                "description": "A boolean key that indicates if the embargo period is currently active. Must be changed to False on the embargo period end date.",
+                "type": [
+                  "boolean",
+                  "null"
+                ],
+                "examples": [
+                  true
+                ],
+                "badge": "Bronze",
+                "title": "Embargo Period is Active "
+              }
+            },
+            "badge": "Bronze",
+            "title": "Embargo Period"
+          },
+          "context": {
+            "description": "An Object that describes the general setting, environment or project leading to the creation or maintenance of this dataset. In science this can be the research project.",
+            "type": "object",
+            "properties": {
+              "title": {
+                "description": "A title of the associated project.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "examples": [
+                  "NFDI4Energy"
+                ],
+                "badge": "Gold",
+                "title": "Context Title"
+              },
+              "homepage": {
+                "description": "A URL of the project.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "examples": [
+                  "https://nfdi4energy.uol.de/"
+                ],
+                "badge": "Gold",
+                "title": "Homepage",
+                "format": "uri"
+              },
+              "documentation": {
+                "description": "A URL of the project documentation.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "examples": [
+                  "https://nfdi4energy.uol.de/sites/about_us/"
+                ],
+                "badge": "Gold",
+                "title": "Documentation"
+              },
+              "sourceCode": {
+                "description": "A URL of the source code of the project.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "examples": [
+                  "https://github.com/NFDI4Energy"
+                ],
+                "badge": "Gold",
+                "title": "Source Code"
+              },
+              "publisher": {
+                "description": "The publishing agency of the data. This can be the OEP.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "examples": [
+                  "Open Energy Platform (OEP)"
+                ],
+                "badge": "Bronze",
+                "title": "Publisher"
+              },
+              "publisherLogo": {
+                "description": "A URL to the logo of the publishing agency of data.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "examples": [
+                  "https://github.com/OpenEnergyPlatform/organisation/blob/production/logo/OpenEnergyFamily_Logo_OpenEnergyPlatform.svg"
+                ],
+                "badge": "Gold",
+                "title": "Publisher Logo",
+                "format": "uri"
+              },
+              "contact": {
+                "description": "A reference to the creator or maintainer of the data set. This can be an email address or a GitHub handle.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "examples": [
+                  "contact@example.com"
+                ],
+                "badge": "Gold",
+                "title": "E-Mail Contact",
+                "format": "email"
+              },
+              "fundingAgency": {
+                "description": "A name of the entity providing the funding. This can be a government agency or a company.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "examples": [
+                  " Deutsche Forschungsgemeinschaft (DFG)"
+                ],
+                "badge": "Gold",
+                "title": "Funding Agency"
+              },
+              "fundingAgencyLogo": {
+                "description": "A URL to the logo or image of the funding agency.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "examples": [
+                  "https://upload.wikimedia.org/wikipedia/commons/8/86/DFG-logo-blau.svg"
+                ],
+                "badge": "Gold",
+                "title": "Funding Agency Logo",
+                "format": "uri"
+              },
+              "grantNo": {
+                "description": "An identifying grant number. In case of a publicly funded project, this number is assigned by the funding agency.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "examples": [
+                  "501865131"
+                ],
+                "badge": "Gold",
+                "title": "Grant Number"
+              }
+            },
+            "badge": "Gold",
+            "title": "Context"
+          },
+          "spatial": {
+            "description": "An object that describes the spatial context of the data.",
+            "type": "object",
+            "properties": {
+              "location": {
+                "description": "An object that describes a covered area or region.",
+                "type": "object",
+                "properties": {
+                  "address": {
+                    "description": "An address of the location of the data. May be specified with street name, house number, zip code, and city name.",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "examples": [
+                      "Rudower Chaussee 12, 12489 Berlin"
+                    ],
+                    "badge": "Silver",
+                    "title": "Address"
+                  },
+                  "@id": {
+                    "description": "A path or URI to a specific location. It can use Wikidata or OpenStreetMap.",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "examples": [
+                      "https://www.wikidata.org/wiki/Q77077223"
+                    ],
+                    "badge": "Platinum",
+                    "title": "Address Identifier"
+                  },
+                  "latitude": {
+                    "description": "The latitude (lat) information of the location. Specifies the north / south position of the geometry.",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "examples": [
+                      "52.432822"
+                    ],
+                    "badge": "Gold",
+                    "title": "Latitude"
+                  },
+                  "longitude": {
+                    "description": "The longitude (lon) information of the location. Specifies the east / west position of the geometry.",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "examples": [
+                      "13.5351004"
+                    ],
+                    "badge": "Gold",
+                    "title": "Longitude"
+                  }
+                },
+                "badge": "Silver",
+                "title": "Location"
+              },
+              "extent": {
+                "description": "An object that describes a covered area or region.",
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "description": "The name of the region.",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "examples": [
+                      "Berlin"
+                    ],
+                    "badge": "Silver",
+                    "title": "Extent Name"
+                  },
+                  "@id": {
+                    "description": "A URI reference for the region.",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "examples": [
+                      "https://www.wikidata.org/wiki/Q64"
+                    ],
+                    "format": "uri",
+                    "badge": "Platinum",
+                    "title": "Extent Identifier"
+                  },
+                  "resolutionValue": {
+                    "description": "The value of the spatial resolution.",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "examples": [
+                      "100"
+                    ],
+                    "badge": "Silver",
+                    "title": "Spatial Resolution Value"
+                  },
+                  "resolutionUnit": {
+                    "description": "The unit of the spatial resolution.",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "examples": [
+                      "m"
+                    ],
+                    "badge": "Silver",
+                    "title": "Spatial Resolution Unit"
+                  },
+                  "boundingBox": {
+                    "description": "The covered area specified by the coordinates of a bounding box. The format is [minLon, minLat, maxLon, maxLat] or [W,S,E,N].",
+                    "type": "array",
+                    "examples": [
+                      13.08825,
+                      52.33859,
+                      13.76104,
+                      52.6754
+                    ],
+                    "items": {
+                      "type": "number"
+                    },
+                    "minItems": 4,
+                    "maxItems": 4,
+                    "badge": "Gold",
+                    "title": "Bounding Box"
+                  },
+                  "crs": {
+                    "description": "The Coordinate Reference System, specified as an EPSG code.",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "examples": [
+                      "EPSG:4326"
+                    ],
+                    "badge": "Gold",
+                    "title": " Coordinate Reference System (CRS)"
+                  }
+                },
+                "badge": "Silver",
+                "title": "Extent"
+              }
+            },
+            "badge": "Silver",
+            "title": "Spatial"
+          },
+          "temporal": {
+            "description": "An object with the time period covered in the data. Temporal information should contain a \"referenceDate\" or the keys that describe a time series, or both.",
+            "type": "object",
+            "properties": {
+              "referenceDate": {
+                "description": "A base year, month or day. The time for which the data should be accurate. Date Format is ISO 8601.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "examples": [
+                  "2020-01-01"
+                ],
+                "badge": "Silver",
+                "title": "Reference Date",
+                "format": "date"
+              },
+              "timeseries": {
+                "description": "An array that describe the timeseries.",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "start": {
+                      "description": "The start time of a time series.",
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "examples": [
+                        "2020-01-01T00:00:00+01:00"
+                      ],
+                      "badge": "Silver",
+                      "title": "Timeseries Start",
+                      "format": "date-time"
+                    },
+                    "end": {
+                      "description": "The temporal end point of a time series.",
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "examples": [
+                        "2020-01-01T23:59:30+01:00"
+                      ],
+                      "badge": "Silver",
+                      "title": "Timeseries End",
+                      "format": "date-time"
+                    },
+                    "resolutionValue": {
+                      "description": "The time span between individual information points in a time series. The value of the resolution.",
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "examples": [
+                        "15"
+                      ],
+                      "badge": "Silver",
+                      "title": "Timeseries Resolution Value"
+                    },
+                    "resolutionUnit": {
+                      "description": "The unit of the temporal resolution.",
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "examples": [
+                        "min"
+                      ],
+                      "badge": "Silver",
+                      "title": "Timeseries Resolution Unit"
+                    },
+                    "alignment": {
+                      "description": "An indicator of whether timestamps in a time series are to the left, right or in the centre.",
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "examples": [
+                        "left"
+                      ],
+                      "badge": "Gold",
+                      "title": "Timeseries Alignment"
+                    },
+                    "aggregationType": {
+                      "description": "An indicator of whether the values are a sum, an average or a current value.",
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "examples": [
+                        "current"
+                      ],
+                      "badge": "Gold",
+                      "title": "Timeseries Aggregation Type"
+                    }
+                  },
+                  "badge": "Silver",
+                  "title": "Timeseries"
+                },
+                "badge": "Silver",
+                "title": "Timeseries"
+              }
+            },
+            "badge": "Silver",
+            "title": "Temporal"
+          },
+          "sources": {
+            "description": "An array of objects with the used and underlying sources of the data and metadata.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "description": "A human readable title of the source, a document title or organisation name.",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "examples": [
+                    "IPCC Sixth Assessment Report (AR6) - Climate Change 2023 - Synthesis Report"
+                  ],
+                  "badge": "Bronze",
+                  "title": "Source Title"
+                },
+                "authors": {
+                  "description": "An array of the full names of the authors of the source material.",
+                  "type": "array",
+                  "items": {
+                    "description": "The authors of the source.",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "examples": [
+                      "Hoesung Lee",
+                      "José Romero",
+                      "The Core Writing Team"
+                    ],
+                    "badge": "Bronze",
+                    "title": "Author"
+                  },
+                  "badge": "Bronze",
+                  "title": "Authors"
+                },
+                "description": {
+                  "description": "A free text description of the source.",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "examples": [
+                    "A Report of the Intergovernmental Panel on Climate Change."
+                  ],
+                  "badge": "Bronze",
+                  "title": "Source Description"
+                },
+                "publicationYear": {
+                  "description": "Indicates the year when the work was published.",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "examples": [
+                    "2023"
+                  ],
+                  "badge": "Bronze",
+                  "title": "Publication Year"
+                },
+                "path": {
+                  "description": "A DOI or link to the original source.",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "examples": [
+                    "https://www.ipcc.ch/report/ar6/syr/downloads/report/IPCC_AR6_SYR_FullVolume.pdf"
+                  ],
+                  "badge": "Bronze",
+                  "title": "DOI",
+                  "format": "uri"
+                },
+                "sourceLicenses": {
+                  "type": "array",
+                  "items": {
+                    "description": "An array of objects of licenses under which the described source is provided. See https://openenergyplatform.github.io/academy/courses/08_licensing/ for further information.",
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "description": "The SPDX identifier.",
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "examples": [
+                          "CC-BY-4.0"
+                        ],
+                        "badge": "Bronze",
+                        "title": "Name"
+                      },
+                      "title": {
+                        "description": "The official (human readable) title of the license.",
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "examples": [
+                          "Creative Commons Attribution 4.0 International"
+                        ],
+                        "badge": "Bronze",
+                        "title": "Title"
+                      },
+                      "path": {
+                        "description": "A link or path to the license text.",
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "examples": [
+                          "https://creativecommons.org/licenses/by/4.0/legalcode"
+                        ],
+                        "badge": "Bronze",
+                        "title": "License Identifier",
+                        "format": "uri"
+                      },
+                      "instruction": {
+                        "description": "A short description of rights and obligations. The use of tl;drLegal is recommended.",
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "examples": [
+                          "You are free to share and change, but you must attribute. See https://www.tldrlegal.com/license/creative-commons-attribution-4-0-international-cc-by-4 for further information."
+                        ],
+                        "badge": "Bronze",
+                        "title": "Instruction"
+                      },
+                      "attribution": {
+                        "description": "A copyright owner of the source. Must be provided if attribution licenses are used.",
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "examples": [
+                          "© Intergovernmental Panel on Climate Change 2023"
+                        ],
+                        "badge": "Bronze",
+                        "title": "Attribution"
+                      },
+                      "copyrightStatement": {
+                        "description": "A link or path that proves that the source or data has the appropriate license. This can be a page number or website imprint.",
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "examples": [
+                          "https://www.ipcc.ch/copyright/"
+                        ],
+                        "badge": "Bronze",
+                        "title": "Copyright Statement"
+                      }
+                    },
+                    "badge": "Bronze",
+                    "title": "Licenses"
+                  },
+                  "badge": "Bronze",
+                  "title": "Licenses"
+                }
+              },
+              "badge": "Bronze",
+              "title": "Sources"
+            },
+            "badge": "Bronze",
+            "title": "Sources"
+          },
+          "licenses": {
+            "description": "An array of objects of licenses under which the described data is provided.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "description": "The SPDX identifier.",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "examples": [
+                    "ODbL-1.0"
+                  ],
+                  "badge": "Bronze",
+                  "title": "Name"
+                },
+                "title": {
+                  "description": "The official (human readable) title of the license.",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "examples": [
+                    "Open Data Commons Open Database License 1.0"
+                  ],
+                  "badge": "Bronze",
+                  "title": "Title"
+                },
+                "path": {
+                  "description": "A link or path to the license text.",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "examples": [
+                    "https://opendatacommons.org/licenses/odbl/1-0/index.html"
+                  ],
+                  "badge": "Bronze",
+                  "title": "Path",
+                  "format": "uri"
+                },
+                "instruction": {
+                  "description": "A short description of rights and obligations. The use of tl;drLegal is recommended.",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "examples": [
+                    "You are free to share and change, but you must attribute, and share derivations under the same license. See https://tldrlegal.com/license/odc-open-database-license-(odbl) for further information."
+                  ],
+                  "badge": "Bronze",
+                  "title": "Instruction"
+                },
+                "attribution": {
+                  "description": "A copyright holder of the data. Must be provided if attribution licenses are used.",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "examples": [
+                    "© Reiner Lemoine Institut"
+                  ],
+                  "badge": "Bronze",
+                  "title": "Attribution"
+                },
+                "copyrightStatement": {
+                  "description": "A link or path that proves that the source or data has the appropriate license. This can be a page number or website imprint.",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "examples": [
+                    "https://github.com/OpenEnergyPlatform/oemetadata/blob/production/LICENSE.txt"
+                  ],
+                  "badge": "Bronze",
+                  "title": "Copyright Statement"
+                }
+              },
+              "badge": "Bronze",
+              "title": "License"
+            },
+            "badge": "Bronze",
+            "title": "Licenses"
+          },
+          "contributors": {
+            "description": "An array of objects of contributors and contributions to the data or metadata.",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "title": {
+                  "description": "A full name of the contributor.",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "examples": [
+                    "Ludwig Hülk"
+                  ],
+                  "badge": "Bronze",
+                  "title": "Contributor Title"
+                },
+                "path": {
+                  "description": "A qualified link or path pointing to a relevant location online for the contributor. This can be the GitHub page or ORCID.",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "examples": [
+                    "https://github.com/Ludee"
+                  ],
+                  "badge": "Bronze",
+                  "title": "Path"
+                },
+                "organization": {
+                  "description": "A string describing the organization this contributor is affiliated to. This can be relevant for the copyright.",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "examples": [
+                    "Reiner Lemoine Institut"
+                  ],
+                  "badge": "Bronze",
+                  "title": "Organization"
+                },
+                "roles": {
+                  "description": "An array describing the roles of the contributor.",
+                  "type": "array",
+                  "items": {
+                    "description": "A role is recommended to follow an established vocabulary: DataCite Metadata Schema’s contributorRole. Useful roles to indicate are: DataCollector, ContactPerson, and DataCurator.",
+                    "type": [
+                      "string",
+                      "null"
+                    ],
+                    "examples": [
+                      "DataCollector",
+                      "DataCurator"
+                    ],
+                    "badge": "Bronze",
+                    "title": "Role"
+                  },
+                  "badge": "Bronze",
+                  "title": "Roles"
+                },
+                "date": {
+                  "description": "The date of the contribution. Date Format is ISO 8601.",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "examples": [
+                    "2024-10-21"
+                  ],
+                  "badge": "Bronze",
+                  "title": "Date",
+                  "format": "date"
+                },
+                "object": {
+                  "description": "The object of the contribution. Which part of the package was supplied or changed.",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "examples": [
+                    "data and metadata"
+                  ],
+                  "badge": "Bronze",
+                  "title": "Object"
+                },
+                "comment": {
+                  "description": "A free-text commentary on what has been done.",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "examples": [
+                    "Add metadata example."
+                  ],
+                  "badge": "Bronze",
+                  "title": "Comment"
+                }
+              },
+              "badge": "Bronze",
+              "title": "Contributor"
+            },
+            "badge": "Bronze",
+            "title": "Contributors"
+          },
+          "type": {
+            "description": "The 'table' type indicates that the resource is tabular as per 'Frictionless Tabular Data' definition.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "examples": [
+              "table"
+            ],
+            "badge": "Gold",
+            "title": "Type",
+            "options": {
+              "hidden": true
+            }
+          },
+          "format": {
+            "description": "A file extension format. Possible options are 'csv', 'xlsx', 'json', 'PostgreSQL', 'SQLite' and other standard file extensions.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "examples": [
+              "CSV"
+            ],
+            "badge": "Gold",
+            "title": "Format",
+            "options": {
+              "hidden": true
+            }
+          },
+          "encoding": {
+            "description": "Specifies the character encoding of the resource's data file. The default is 'UTF-8'. The values should be one of the 'Preferred MIME Names'.",
+            "type": [
+              "string",
+              "null"
+            ],
+            "examples": [
+              "UTF-8"
+            ],
+            "badge": "Gold",
+            "title": "Encoding",
+            "options": {
+              "hidden": true
+            }
+          },
+          "schema": {
+            "description": "An object that describes the structure of a table. It contains all fields (columns of the table), the primary key and optional foreign keys.",
+            "type": "object",
+            "properties": {
+              "fields": {
+                "description": "An array of objects that describes a field (column) and its detailed information.",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "description": "The name of the field. The name may only consist of lowercase alphanumeric characters or underscores. It must not begin with a number or an underscore.",
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "examples": [
+                        "year"
+                      ],
+                      "badge": "Iron",
+                      "title": "Column Name",
+                      "readOnly": true
+                    },
+                    "description": {
+                      "description": "A text describing the field.",
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "examples": [
+                        "Reference year for which the data was collected."
+                      ],
+                      "badge": "Silver",
+                      "title": "Description"
+                    },
+                    "type": {
+                      "description": "The data type of the field. In case of a geom column in a database, also indicate the shape and CRS.",
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "examples": [
+                        "geometry(Point, 4326)"
+                      ],
+                      "badge": "Iron",
+                      "title": "Type",
+                      "readOnly": true
+                    },
+                    "nullable": {
+                      "description": "A boolean key to specify that a column can be nullable. True is the default value.",
+                      "type": [
+                        "boolean",
+                        "null"
+                      ],
+                      "examples": [
+                        true
+                      ],
+                      "badge": "Iron",
+                      "title": "Nullable",
+                      "readOnly": true
+                    },
+                    "unit": {
+                      "description": "The unit of a field. If it does not apply, use 'null'. If the unit is given in a separate field, reference this field (e.g. 'unit'). Use a space between numbers and units (100 m).",
+                      "type": [
+                        "string",
+                        "null"
+                      ],
+                      "examples": [
+                        "MW"
+                      ],
+                      "badge": "Silver",
+                      "title": "Unit"
+                    },
+                    "isAbout": {
+                      "description": "An array of objects that describes the field in ontology terms.",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": {
+                            "description": "The class label of the ontology term.",
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "examples": [
+                              "wind energy converting unit"
+                            ],
+                            "badge": "Platinum",
+                            "title": "Is About Name"
+                          },
+                          "@id": {
+                            "description": "The path of the ontology term (IRI).",
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "examples": [
+                              "https://openenergyplatform.org/ontology/oeo/OEO_00000044"
+                            ],
+                            "badge": "Platinum",
+                            "title": "Is About Identifier",
+                            "format": "uri"
+                          }
+                        },
+                        "badge": "Platinum",
+                        "title": "isAbout"
+                      },
+                      "badge": "Platinum",
+                      "title": "isAbout"
+                    },
+                    "valueReference": {
+                      "description": "An array of objects for an extended description of the values in the column in ontology terms.",
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "value": {
+                            "description": "The name of the value in the column.",
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "examples": [
+                              "onshore"
+                            ],
+                            "badge": "Platinum",
+                            "title": "Value Reference"
+                          },
+                          "name": {
+                            "description": "The class label of the ontology term in the column.",
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "examples": [
+                              "onshore wind farm"
+                            ],
+                            "badge": "Platinum",
+                            "title": "Value Reference Name"
+                          },
+                          "@id": {
+                            "description": "The path of the ontology term (IRI) in the column.",
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "examples": [
+                              "https://openenergyplatform.org/ontology/oeo/OEO_00000311"
+                            ],
+                            "badge": "Platinum",
+                            "title": "Value Reference Identifier",
+                            "format": "uri"
+                          }
+                        },
+                        "badge": "Platinum",
+                        "title": "valueReference"
+                      },
+                      "badge": "Platinum",
+                      "title": "valueReference"
+                    }
+                  },
+                  "title": "Field",
+                  "required": [
+                    "name",
+                    "type",
+                    "nullable"
+                  ]
+                },
+                "title": "Field"
+              },
+              "primaryKey": {
+                "description": "An array of fields that uniquely identifies each row in the table.",
+                "type": "array",
+                "items": {
+                  "description": "The default value is the “id” column.",
+                  "type": [
+                    "string",
+                    "null"
+                  ],
+                  "examples": [
+                    "id"
+                  ],
+                  "badge": "Iron",
+                  "title": "Primary key"
+                },
+                "badge": "Iron",
+                "title": "Primary key"
+              },
+              "foreignKeys": {
+                "description": "List of foreign keys.",
+                "type": "array",
+                "items": {
+                  "description": "An array of objects with foreign keys that describe a field that relates to a field in another table.",
+                  "type": "object",
+                  "properties": {
+                    "fields": {
+                      "description": "An array of fields in the table that is constrained by the foreign key.",
+                      "type": "array",
+                      "items": {
+                        "description": "The column in the table that is constrained by the foreign key.",
+                        "type": [
+                          "string",
+                          "null"
+                        ],
+                        "examples": [
+                          "id",
+                          "version"
+                        ],
+                        "badge": "Iron",
+                        "title": "Foreign Key Field"
+                      },
+                      "badge": "Iron",
+                      "title": "Fields"
+                    },
+                    "reference": {
+                      "description": "The reference to the foreign table.",
+                      "type": "object",
+                      "properties": {
+                        "resource": {
+                          "description": "The referenced foreign table.",
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "examples": [
+                            "model_draft.oep_oemetadata_table_example_version"
+                          ],
+                          "badge": "Iron",
+                          "title": "Foreign Resource"
+                        },
+                        "fields": {
+                          "description": "The foreign resource column.",
+                          "type": "array",
+                          "items": {
+                            "description": "The foreign resource column.",
+                            "type": [
+                              "string",
+                              "null"
+                            ],
+                            "examples": [
+                              "id",
+                              "version"
+                            ],
+                            "badge": "Iron",
+                            "title": "Field"
+                          },
+                          "badge": "Iron",
+                          "title": "Field"
+                        }
+                      },
+                      "badge": "Iron",
+                      "title": "Reference",
+                      "required": [
+                        "resource",
+                        "fields"
+                      ]
+                    }
+                  },
+                  "title": "Foreign Key",
+                  "required": [
+                    "fields"
+                  ]
+                },
+                "badge": "Iron",
+                "title": "Foreign Keys"
+              }
+            },
+            "title": "Schema",
+            "required": [
+              "primaryKey"
+            ]
+          },
+          "dialect": {
+            "description": "The Dialect defines a simple format for describing the various dialects of CSV files in a language-independent manner. In a database, the values in the fields are 'null'.",
+            "type": "object",
+            "properties": {
+              "delimiter": {
+                "description": "The delimiter specifies the character sequence which should separate fields (columns). Common characters are ',' (comma), ';' (semicolon), '.' (point) and '\\t' (tab).",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "examples": [
+                  ";"
+                ],
+                "badge": "Silver",
+                "title": "Delimiter"
+              },
+              "decimalSeparator": {
+                "description": "The symbol used to separate the integer part from the fractional part of a number written in decimal form. Depending on language and region this symbol can be '.' or ','.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "examples": [
+                  "."
+                ],
+                "badge": "Silver",
+                "title": "Decimal separator"
+              }
+            },
+            "badge": "Silver",
+            "title": "Dialect",
+            "options": {
+              "hidden": true
+            }
+          },
+          "review": {
+            "description": "The metadata on the OEP can go through an open peer review process. See the Academy course [Open Peer Review](https://openenergyplatform.github.io/academy/courses/09_peer_review/) for further information.",
+            "type": "object",
+            "properties": {
+              "path": {
+                "description": "A link or path to the documented open peer review.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "examples": [
+                  "https://openenergyplatform.org/dataedit/view/model_draft/oep_table_example/open_peer_review/"
+                ],
+                "badge": null,
+                "title": "Path",
+                "format": "uri"
+              },
+              "badge": {
+                "description": "A badge of either Iron, Bronze, Silver, Gold or Platinum is used to label the quality of the metadata.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "examples": [
+                  "Platinum"
+                ],
+                "badge": null,
+                "title": "Badge"
+              }
+            },
+            "title": "Review",
+            "options": {
+              "hidden": true
+            }
+          }
+        }
+      },
+      "title": "Resources"
+    },
+    "metaMetadata": {
+      "description": "An object that describes the metadata themselves, their format, version and license.",
+      "type": "object",
+      "properties": {
+        "metadataVersion": {
+          "description": "Type and version number of the metadata.",
+          "examples": [
+            "OEMetadata-2.0.4"
+          ],
+          "type": [
+            "string",
+            "null"
+          ],
+          "badge": null,
+          "title": "Metadata Version"
+        },
+        "metadataLicense": {
+          "description": "The license of the OEMetadata. ",
+          "type": "object",
+          "properties": {
+            "name": {
+              "description": "The SPDX identifier.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "examples": [
+                "CC0-1.0"
+              ],
+              "badge": null,
+              "title": "License Name"
+            },
+            "title": {
+              "description": "The official (human readable) title of the license.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "examples": [
+                "Creative Commons Zero v1.0 Universal"
+              ],
+              "badge": null,
+              "title": "License Title"
+            },
+            "path": {
+              "description": "A link or path to the license text.",
+              "type": [
+                "string",
+                "null"
+              ],
+              "examples": [
+                "https://creativecommons.org/publicdomain/zero/1.0"
+              ],
+              "badge": null,
+              "title": "License Path",
+              "format": "uri"
+            }
+          },
+          "badge": null,
+          "title": "Metadata License"
+        }
+      },
+      "title": "Meta Metadata",
+      "options": {
+        "hidden": true
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/oemetadata/v2/v21/schema.py
+++ b/oemetadata/v2/v21/schema.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2024 Ludwig Hülk <@Ludee> © Reiner Lemoine Institut
+# SPDX-FileCopyrightText: 2024 Jonas Huber <jh-RLI> © Reiner Lemoine Institut
+# SPDX-FileCopyrightText: oemetadata <https://github.com/OpenEnergyPlatform/oemetadata/>
+# SPDX-License-Identifier: MIT
+
+import json
+import os
+
+
+with open(os.path.join(os.path.dirname(__file__), "schema.json"), "rb") as f:
+    OEMETADATA_V20_SCHEMA = json.loads(f.read())

--- a/oemetadata/v2/v21/template.json
+++ b/oemetadata/v2/v21/template.json
@@ -1,0 +1,186 @@
+{
+  "@context": "",
+  "name": "",
+  "title": "",
+  "description": "",
+  "@id": "",
+  "resources": [
+    {
+      "@id": "",
+      "name": "",
+      "topics": [
+        ""
+      ],
+      "title": "",
+      "path": "",
+      "description": "",
+      "languages": [
+        ""
+      ],
+      "subject": [
+        {
+          "name": "",
+          "@id": ""
+        }
+      ],
+      "keywords": [
+        ""
+      ],
+      "publicationDate": "",
+      "embargoPeriod": {
+        "start": "",
+        "end": "",
+        "isActive": false
+      },
+      "context": {
+        "title": "",
+        "homepage": "",
+        "documentation": "",
+        "sourceCode": "",
+        "publisher": "",
+        "publisherLogo": "",
+        "contact": "",
+        "fundingAgency": "",
+        "fundingAgencyLogo": "",
+        "grantNo": ""
+      },
+      "spatial": {
+        "location": {
+          "address": "",
+          "@id": "",
+          "latitude": "",
+          "longitude": ""
+        },
+        "extent": {
+          "name": "",
+          "@id": "",
+          "resolutionValue": "",
+          "resolutionUnit": "",
+          "boundingBox": [
+            0,
+            0,
+            0,
+            0
+          ],
+          "crs": ""
+        }
+      },
+      "temporal": {
+        "referenceDate": "",
+        "timeseries": [
+          {
+            "start": "",
+            "end": "",
+            "resolutionValue": "",
+            "resolutionUnit": "",
+            "alignment": "",
+            "aggregationType": ""
+          }
+        ]
+      },
+      "sources": [
+        {
+          "title": "",
+          "authors": [
+            ""
+          ],
+          "description": "",
+          "publicationYear": "",
+          "path": "",
+          "sourceLicenses": [
+            {
+              "name": "",
+              "title": "",
+              "path": "",
+              "instruction": "",
+              "attribution": "",
+              "copyrightStatement": ""
+            }
+          ]
+        }
+      ],
+      "licenses": [
+        {
+          "name": "",
+          "title": "",
+          "path": "",
+          "instruction": "",
+          "attribution": "",
+          "copyrightStatement": ""
+        }
+      ],
+      "contributors": [
+        {
+          "title": "",
+          "path": "",
+          "organization": "",
+          "roles": [
+            ""
+          ],
+          "date": "",
+          "object": "",
+          "comment": ""
+        }
+      ],
+      "type": "",
+      "format": "",
+      "encoding": "",
+      "schema": {
+        "fields": [
+          {
+            "name": "",
+            "description": "",
+            "type": "",
+            "nullable": false,
+            "unit": "",
+            "isAbout": [
+              {
+                "name": "",
+                "@id": ""
+              }
+            ],
+            "valueReference": [
+              {
+                "value": "",
+                "name": "",
+                "@id": ""
+              }
+            ]
+          }
+        ],
+        "primaryKey": [
+          ""
+        ],
+        "foreignKeys": [
+          {
+            "fields": [
+              ""
+            ],
+            "reference": {
+              "resource": "",
+              "fields": [
+                ""
+              ]
+            }
+          }
+        ]
+      },
+      "dialect": {
+        "delimiter": "",
+        "decimalSeparator": ""
+      },
+      "review": {
+        "path": "",
+        "badge": ""
+      }
+    }
+  ],
+  "metaMetadata": {
+    "metadataVersion": "OEMetadata-2.0.4",
+    "metadataLicense": {
+      "name": "CC0-1.0",
+      "title": "Creative Commons Zero v1.0 Universal",
+      "path": "https://creativecommons.org/publicdomain/zero/1.0"
+    }
+  }
+}

--- a/oemetadata/v2/v21/template.py
+++ b/oemetadata/v2/v21/template.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2024 Ludwig Hülk <@Ludee> © Reiner Lemoine Institut
+# SPDX-FileCopyrightText: 2024 Jonas Huber <jh-RLI> © Reiner Lemoine Institut
+# SPDX-FileCopyrightText: oemetadata <https://github.com/OpenEnergyPlatform/oemetadata/>
+# SPDX-License-Identifier: MIT
+
+import json
+import os
+
+
+with open(os.path.join(os.path.dirname(__file__), "template.json"), "rb") as f:
+    OEMETADATA_V20_TEMPLATE = json.loads(f.read())


### PR DESCRIPTION
## Summary of the discussion

The role "Creator" or "DatasetCreator" is not part of the DataCite contributorType. But is completely clear.

Having 3 default entries in the "contributors" section is suggested:
```json
"roles": ["Creator"], "object": "dataset",
"roles": ["DataCollector"], "object": "data",
"roles": ["DataCurator"], "object": "metadata",
```

## Type of change (CHANGELOG.md)

### Added
- Dataset creator to contributors [(#304)](https://github.com/OpenEnergyPlatform/oemetadata/pull/304)

## Workflow checklist

### Automation

Part of #296 Closes #293 

### PR-Assignee

- [x] 🐙 Follow the workflow in [CONTRIBUTING.md](https://github.com/OpenEnergyPlatform/oemetadata/blob/production/CONTRIBUTING.md)
- [x] 📝 Update the [CHANGELOG.md](https://github.com/OpenEnergyPlatform/oemetadata/blob/production/CHANGELOG.md)
- [x] 📙 Update the documentation
- [x] 🐙 Assign a reviewer to the PR

### Reviewer

- [x] 🐙 Follow the [Reviewer Guidelines](https://github.com/OpenEnergyPlatform/oemetadata/blob/production/CONTRIBUTING.md#40--let-someone-else-review-your-pr)
- [x] 🐙 Provided feedback and show sufficient appreciation for the work done
